### PR TITLE
fix: Create all directories before writing to it

### DIFF
--- a/scripts/setupmac.js
+++ b/scripts/setupmac.js
@@ -2,7 +2,7 @@ const { https } = require('follow-redirects');
 const fs = require('fs');
 const { spawn, spawnSync } = require('child_process');
 
-fs.mkdirSync("./resources/darwin", { recursive: true });
+fs.mkdirSync("./resources/darwin/bin", { recursive: true });
 
 const file = fs.createWriteStream("./resources/darwin/minikube");
 https.get("https://github.com/kubernetes/minikube/releases/download/v1.14.0/minikube-darwin-amd64", function(response) {


### PR DESCRIPTION
Additional fix on top of #1 to create the directory needed to download kubectl.