### PR TITLE
Fix downloading the helm binary

### DIFF
--- a/scripts/setupmac.js
+++ b/scripts/setupmac.js
@@ -38,7 +38,7 @@ https.get("https://get.helm.sh/helm-v3.4.1-darwin-amd64.tar.gz", function(respon
   response.on('end', () => {
     file3.end();
     spawn('tar', ['-zxvf', '/tmp/helm-v3.4.1-darwin-amd64.tar.gz', '--directory', "/tmp/"]).on('exit', (code, sig) => {
-      spawn('mv', ['/tmp/darwin-amd64/helm', process.cwd() + '/resources/darwin/bin/helm']).on('exit', () => {
+      spawn('cp', ['-f', '/tmp/darwin-amd64/helm', process.cwd() + '/resources/darwin/bin/helm']).on('exit', () => {
         spawnSync('rm', ['-rf', '/tmp/helm-v3.4.1-darwin-amd64.tar.gz', '/tmp/darwin-amd64']);
         spawnSync('chmod', ['+x', process.cwd() + '/resources/darwin/bin/helm']);
       }).stderr.on('data', (data) => {


### PR DESCRIPTION
tarball extraction has to wait until the file is fully downloaded to avoid the error "truncated gzip input".

Also extracted files inherit group ownership from the parent directory; in case of `/tmp` this is "wheel" (gid 0). This throws an error when the file is moved to a different volume, e.g.

mv: /Volumes/[...]/bin/helm: set owner/group (was: 501/0): Operation not permitted

Using `cp -f` avoids this problem.