### PR TITLE
Add commonly used editor cruft to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ node_modules
 resources/darwin/minikube
 resources/darwin/bin/
 dist
+.idea/
+*~


### PR DESCRIPTION
- goland & other jetbrains IDEs create local .idea dirs
- emacs writes backups in X~ files