### PR TITLE
Move settings writing to the main process

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,4 +1,5 @@
 const { app, ipcMain, dialog } = require('electron');
+const deepmerge = require('deepmerge');
 const settings = require('./src/config/settings.js');
 const tray = require('./src/menu/tray.js');
 const window = require('./src/window/window.js');
@@ -8,6 +9,7 @@ const K8s = require('./src/k8s-engine/k8s.js');
 app.setName("Rancher Desktop");
 
 let k8smanager;
+let cfg;
 
 app.whenReady().then(() => {
 
@@ -16,7 +18,7 @@ app.whenReady().then(() => {
   // TODO: Check if first install and start welcome screen
   // TODO: Check if new version and provide window with details on changes
 
-  let cfg = settings.init();
+  cfg = settings.init();
   console.log(cfg);
   k8smanager = K8s.factory(cfg.kubernetes);
 
@@ -51,6 +53,16 @@ app.on('window-all-closed', () => {
     app.quit();
   }
 })
+
+ipcMain.on('settings-read', (event) => {
+  event.returnValue = cfg;
+});
+
+ipcMain.handle('settings-write', async (event, arg) => {
+  cfg = deepmerge(cfg, arg);
+  settings.save(cfg);
+  event.sender.sendToFrame(event.frameId, 'settings-update', cfg);
+});
 
 ipcMain.on('k8s-state', (event) => {
   event.returnValue = k8smanager.state;

--- a/background.js
+++ b/background.js
@@ -93,6 +93,10 @@ ipcMain.on('k8s-reset', (event, arg) => {
         console.log(`Deleted minikube to reset exited with code ${code}`);
       })
       .then(() => {
+        // The desired Kubernetes version might have changed
+        k8smanager = K8s.factory(cfg.kubernetes);
+      })
+      .then(() => {
         return k8smanager.start();
       })
       .then((code) => {
@@ -122,6 +126,10 @@ ipcMain.on('k8s-restart', () => {
     k8smanager.stop()
       .then(() => {
         tray.k8sRestarting();
+      })
+      .then(() => {
+        // The desired Kubernetes version might have changed
+        k8smanager = K8s.factory(cfg.kubernetes);
       })
       .then(() => { k8smanager.start() })
       .then(() => {


### PR DESCRIPTION
This moves writing the settings to the main process (rather than doing it from the web process), so that the two is never out of sync.

Additionally, when restarting or resetting Kubernetes (likely due to a version change), recreate the `k8smanager` so that it has the correct version in mind.

(Not very familiar with node/electron yet; please let me know of any suggestions, thanks!)