### PR TITLE
Add GitHub Actions script to run lint

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,16 @@
+name: Lint
+
+on:
+  push: {}
+  pull_request: {}
+
+jobs:
+  lint:
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        persist-credentials: false
+    - uses: actions/setup-node@v1
+    - run: npm ci
+    - run: npm run lint


### PR DESCRIPTION
This adds a GitHub Action for linting on PRs & commits.  Fixes #11.

I assume this is cheap enough that running it on all pushes & PRs is acceptable.