### PR TITLE
Have tray watch the state instead of passive notification

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,5 +1,6 @@
 module.exports = {
   presets: [
     '@vue/cli-plugin-babel/preset'
-  ]
+  ],
+  plugins: ["@babel/plugin-proposal-private-methods"]
 }

--- a/background.js
+++ b/background.js
@@ -19,12 +19,12 @@ app.whenReady().then(() => {
   let cfg = settings.init();
   console.log(cfg);
   k8smanager = K8s.factory(cfg.kubernetes);
+  k8smanager.on("state-changed", (state) => {
+    tray.k8sStateChanged(state);
+  })
 
   k8smanager.start().then((code) => {
     console.log(`1: Child exited with code ${code}`);
-    if (k8smanager.state === K8s.State.STARTED) {
-      tray.k8sStarted();
-    }
   }, startfailed);
 
   window.createWindow();
@@ -34,7 +34,6 @@ let gone = false;
 app.on('before-quit', (event) => {
   if (gone) return;
   event.preventDefault();
-  tray.k8sStopping();
 
   k8smanager.stop()
     .finally((code) => {
@@ -62,11 +61,9 @@ ipcMain.on('k8s-reset', (event, arg) => {
     if (k8smanager.state != K8s.State.STARTED && k8smanager.state != K8s.State.STOPPED) {
       return;
     }
-    tray.k8sStopping();
     k8smanager.stop()
       .then((code) => {
         console.log(`Stopped minikube with code ${code}`);
-        tray.k8sRestarting();
         console.log(`Deleting minikube to reset...`);
         try {
           event.reply('k8s-check-state', k8smanager.state);
@@ -84,7 +81,6 @@ ipcMain.on('k8s-reset', (event, arg) => {
         return k8smanager.start();
       })
       .then((code) => {
-        tray.k8sStarted();
         try {
           event.reply('k8s-check-state', k8smanager.state);
         } catch (err) {
@@ -103,17 +99,11 @@ ipcMain.on('k8s-restart', () => {
   if (k8smanager.state === K8s.State.STOPPED) {
     k8smanager.start().then((code) => {
       console.log(`3: Child exited with code ${code}`);
-      tray.k8sStarted();
     }, startfailed);
   } else if (k8smanager.state === K8s.State.STARTED) {
-    tray.k8sStopping();
     k8smanager.stop()
-      .then(() => {
-        tray.k8sRestarting();
-      })
       .then(() => { k8smanager.start() })
       .then(() => {
-        tray.k8sStarted();
       }, startfailed);
   }
 })


### PR DESCRIPTION
This should help in getting the tray state to always match the internal state (since it no longer relies on random places calling the tray to update).  It also makes the Kubernetes backend an `EventEmitter` to emit on state changes.

This is the change mentioned in https://github.com/mattfarina/rd/pull/17#issuecomment-742896623 — by decoupling the state notifications from the state transitions, we can better ensure that we don't forget to notify on one of them.

I'm not entirely happy with the `#internalstate` mess — but I wanted to have a setter to ensure we don't miss emitting somewhere.