### PR TITLE
Allow the user to opt into showing the dev tools window

### DIFF
--- a/background.js
+++ b/background.js
@@ -5,6 +5,7 @@ const window = require('./src/window/window.js');
 const K8s = require('./src/k8s-engine/k8s.js');
 // TODO: rewrite in typescript. This was just a quick proof of concept.
 
+let cfg = settings.init(app.commandLine);
 app.setName("Rancher Desktop");
 
 let k8smanager;
@@ -16,7 +17,6 @@ app.whenReady().then(() => {
   // TODO: Check if first install and start welcome screen
   // TODO: Check if new version and provide window with details on changes
 
-  let cfg = settings.init();
   console.log(cfg);
   k8smanager = K8s.factory(cfg.kubernetes);
 
@@ -27,7 +27,7 @@ app.whenReady().then(() => {
     }
   }, startfailed);
 
-  window.createWindow();
+  window.createWindow(cfg);
 })
 
 let gone = false;

--- a/src/window/window.js
+++ b/src/window/window.js
@@ -12,7 +12,7 @@ if (process.env.NODE_ENV === 'DEV') {
 
 let window;
 
-function createWindow() {
+function createWindow(cfg) {
   if (BrowserWindow.getAllWindows().length === 0) {
     window = new BrowserWindow({
       width: 940,
@@ -23,7 +23,9 @@ function createWindow() {
       }
     })
     window.loadURL(url);
-    window.webContents.openDevTools();
+    if (cfg.rd.devtools) {
+      window.webContents.openDevTools();
+    }
   } else {
     if (!window.isFocused()) {
       window.show();


### PR DESCRIPTION
The user can now launch the application with `--enable-devtools` or `--disable-devtools` to opt into / out of showing the devtools window on startup.  The preference is persisted.

This fixes #5.