### PR TITLE
Turning off devtools by default

### DIFF
--- a/src/window/window.js
+++ b/src/window/window.js
@@ -23,7 +23,6 @@ function createWindow() {
       }
     })
     window.loadURL(url);
-    window.webContents.openDevTools();
   } else {
     if (!window.isFocused()) {
       window.show();


### PR DESCRIPTION
We can use the menu or keyboard shortcut to turn it on for now