### PR TITLE
Convert k8s-reset / k8s-restart to async func

### DIFF
--- a/background.js
+++ b/background.js
@@ -65,71 +65,66 @@ ipcMain.on('k8s-state', (event) => {
   event.returnValue = k8smanager.state;
 });
 
-ipcMain.on('k8s-reset', (event, arg) => {
-  if (arg === 'Reset Kubernetes to default') {
-    // If not in a place to restart than skip it
-    if (k8smanager.state != K8s.State.STARTED && k8smanager.state != K8s.State.STOPPED) {
-      return;
-    }
-    k8smanager.stop()
-      .then((code) => {
-        console.log(`Stopped minikube with code ${code}`);
-        console.log(`Deleting minikube to reset...`);
-        try {
-          event.reply('k8s-check-state', k8smanager.state);
-        } catch (err) {
-          console.log(err);
-        }
-      })
-      .then(() => {
-        return k8smanager.del();
-      })
-      .then((code) => {
-        console.log(`Deleted minikube to reset exited with code ${code}`);
-      })
-      .then(() => {
-        // The desired Kubernetes version might have changed
-        k8smanager = newK8sManager(cfg.kubernetes);
-      })
-      .then(() => {
-        return k8smanager.start();
-      })
-      .then((code) => {
-        try {
-          event.reply('k8s-check-state', k8smanager.state);
-        } catch (err) {
-          console.log(err);
-        }
-        console.log(`Starting minikube exited with code ${code}`);
-      }, startfailed);
-  }
-})
+ipcMain.on('k8s-reset', async (event, arg) => {
+  try {
+    if (arg === 'Reset Kubernetes to default') {
+      // If not in a place to restart than skip it
+      if (k8smanager.state != K8s.State.STARTED && k8smanager.state != K8s.State.STOPPED) {
+        return;
+      }
+      let code = await k8smanager.stop();
+      console.log(`Stopped minikube with code ${code}`);
+      console.log(`Deleting minikube to reset...`);
+      try {
+        event.reply('k8s-check-state', k8smanager.state);
+      } catch (err) {
+        console.log(err);
+      }
 
-ipcMain.on('k8s-restart', (event) => {
+      code = await k8smanager.del();
+      console.log(`Deleted minikube to reset exited with code ${code}`);
+
+      // The desired Kubernetes version might have changed
+      k8smanager = newK8sManager(cfg.kubernetes);
+
+      code = await k8smanager.start();
+      try {
+        event.reply('k8s-check-state', k8smanager.state);
+      } catch (err) {
+        console.log(err);
+      }
+      console.log(`Starting minikube exited with code ${code}`);
+    }
+  } catch (ex) {
+    startfailed(ex);
+  }
+});
+
+ipcMain.on('k8s-restart', async (event) => {
   if (k8smanager.state != K8s.State.STARTED && k8smanager.state != K8s.State.STOPPED) {
     return;
   }
 
-  if (k8smanager.state === K8s.State.STOPPED) {
-    k8smanager.start().then((code) => {
+  try {
+    if (k8smanager.state === K8s.State.STOPPED) {
+      let code = await k8smanager.start();
       console.log(`3: Child exited with code ${code}`);
-    }, startfailed);
-  } else if (k8smanager.state === K8s.State.STARTED) {
-    k8smanager.stop()
-      .then(() => {
-        // The desired Kubernetes version might have changed
-        k8smanager = newK8sManager(cfg.kubernetes);
-      })
-      .then(() => { return k8smanager.start() })
-      .then(() => {
-        try {
-          event.reply('k8s-check-state', k8smanager.state);
-        } catch (err) {
-          console.log(err);
-        }
-      }, startfailed);
+    } else if (k8smanager.state === K8s.State.STARTED) {
+      await k8smanager.stop();
+      // The desired Kubernetes version might have changed
+      k8smanager = newK8sManager(cfg.kubernetes);
+
+      await k8smanager.start();
+      try {
+        event.reply('k8s-check-state', k8smanager.state);
+      } catch (err) {
+        console.log(err);
+      }
+    }
+  } catch (ex) {
+    startfailed(ex);
   }
-})
+});
 
 function startfailed(code) {
   dialog.showErrorBox("Error Starting Kuberentes", "Kubernetes was unable to start with the following exit code: " + code);


### PR DESCRIPTION
Convert the two more complicated k8s operation handlers on the main process side to async functions, so that they can read more naturally and avoid confusion when using promise chains.

This actually also exposes the fact that `startfailed` can get exceptions instead of return codes, but I haven't thought about how to fix it yet.