### PR TITLE
Add access to dashboard

### DIFF
--- a/background.js
+++ b/background.js
@@ -118,11 +118,6 @@ ipcMain.on('k8s-reset', async (event, arg) => {
       let code = await k8smanager.stop();
       console.log(`Stopped minikube with code ${code}`);
       console.log(`Deleting minikube to reset...`);
-      try {
-        event.reply('k8s-check-state', k8smanager.state);
-      } catch (err) {
-        console.log(err);
-      }
 
       code = await k8smanager.del();
       console.log(`Deleted minikube to reset exited with code ${code}`);
@@ -131,11 +126,6 @@ ipcMain.on('k8s-reset', async (event, arg) => {
       k8smanager = newK8sManager(cfg.kubernetes);
 
       await k8smanager.start();
-      try {
-        event.reply('k8s-check-state', k8smanager.state);
-      } catch (err) {
-        console.log(err);
-      }
     }
   } catch (ex) {
     handleFailure(ex);
@@ -156,11 +146,6 @@ ipcMain.on('k8s-restart', async (event) => {
       k8smanager = newK8sManager(cfg.kubernetes);
 
       await k8smanager.start();
-      try {
-        event.reply('k8s-check-state', k8smanager.state);
-      } catch (err) {
-        console.log(err);
-      }
     }
   } catch (ex) {
     handleFailure(ex);
@@ -247,6 +232,7 @@ function newK8sManager(cfg) {
   let mgr = K8s.factory(cfg);
   mgr.on("state-changed", (state) => {
     tray.k8sStateChanged(state);
+    window.send("k8s-check-state", state);
   });
 
   return mgr;

--- a/background.js
+++ b/background.js
@@ -171,6 +171,15 @@ ipcMain.on('k8s-restart', async (event) => {
   }
 });
 
+app.on('window-preferences', () => {
+  window.openPreferences();
+  app.dock.show();
+});
+
+app.on('window-dashboard', async () => {
+  window.openDashboard(await k8smanager.homesteadPort());
+});
+
 /**
  * Check if an executable has been installed for the user, and emits the result
  * on the 'install-state' channel, as either true (has been installed), false

--- a/background.js
+++ b/background.js
@@ -139,7 +139,8 @@ ipcMain.on('k8s-restart', async () => {
       case K8s.State.STOPPED:
         await k8smanager.start();
         break;
-      case K8s.State.STARTED, K8s.State.READY:
+      case K8s.State.STARTED:
+      case K8s.State.READY:
         await k8smanager.stop();
         // The desired Kubernetes version might have changed
         k8smanager = newK8sManager(cfg.kubernetes);

--- a/background.js
+++ b/background.js
@@ -234,6 +234,10 @@ function newK8sManager(cfg) {
   mgr.on("state-changed", (state) => {
     tray.k8sStateChanged(state);
     window.send("k8s-check-state", state);
+
+    if (state != K8s.State.READY) {
+      window.closeDashboard();
+    }
   });
 
   return mgr;

--- a/background.js
+++ b/background.js
@@ -60,7 +60,7 @@ app.whenReady().then(() => {
     }
     callback(result);
   });
-  window.createWindow();
+  window.openPreferences();
 })
 
 let gone = false;
@@ -93,7 +93,7 @@ app.on('window-all-closed', () => {
 app.on('activate', () => {
   // On macOS it's common to re-create a window in the app when the
   // dock icon is clicked and there are no other windows open.
-  window.createWindow();
+  window.openPreferences();
 });
 
 ipcMain.on('settings-read', (event) => {

--- a/background.js
+++ b/background.js
@@ -32,9 +32,7 @@ app.whenReady().then(() => {
   console.log(cfg);
   k8smanager = newK8sManager(cfg.kubernetes);
 
-  k8smanager.start().then((code) => {
-    console.log(`1: Child exited with code ${code}`);
-  }, handleFailure);
+  k8smanager.start().catch(handleFailure);
 
   // Set up protocol handler for app://
   // This is needed because in packaged builds we'll not be allowed to access
@@ -132,13 +130,12 @@ ipcMain.on('k8s-reset', async (event, arg) => {
       // The desired Kubernetes version might have changed
       k8smanager = newK8sManager(cfg.kubernetes);
 
-      code = await k8smanager.start();
+      await k8smanager.start();
       try {
         event.reply('k8s-check-state', k8smanager.state);
       } catch (err) {
         console.log(err);
       }
-      console.log(`Starting minikube exited with code ${code}`);
     }
   } catch (ex) {
     handleFailure(ex);
@@ -152,8 +149,7 @@ ipcMain.on('k8s-restart', async (event) => {
 
   try {
     if (k8smanager.state === K8s.State.STOPPED) {
-      let code = await k8smanager.start();
-      console.log(`3: Child exited with code ${code}`);
+      await k8smanager.start();
     } else if (k8smanager.state === K8s.State.STARTED) {
       await k8smanager.stop();
       // The desired Kubernetes version might have changed

--- a/background.js
+++ b/background.js
@@ -110,23 +110,24 @@ ipcMain.on('k8s-state', (event) => {
 
 ipcMain.on('k8s-reset', async (event, arg) => {
   try {
-    if (arg === 'Reset Kubernetes to default') {
-      // If not in a place to restart than skip it
-      if ([K8s.State.STARTED, K8s.State.READY, K8s.State.STOPPED].indexOf(k8smanager.state) >= 0) {
-        return;
-      }
-      let code = await k8smanager.stop();
-      console.log(`Stopped minikube with code ${code}`);
-      console.log(`Deleting minikube to reset...`);
-
-      code = await k8smanager.del();
-      console.log(`Deleted minikube to reset exited with code ${code}`);
-
-      // The desired Kubernetes version might have changed
-      k8smanager = newK8sManager(cfg.kubernetes);
-
-      await k8smanager.start();
+    if (arg !== 'Reset Kubernetes to default') {
+      return;
     }
+    // If not in a place to restart than skip it
+    if ([K8s.State.STARTED, K8s.State.READY, K8s.State.STOPPED].indexOf(k8smanager.state) < 0) {
+      return;
+    }
+    let code = await k8smanager.stop();
+    console.log(`Stopped minikube with code ${code}`);
+    console.log(`Deleting minikube to reset...`);
+
+    code = await k8smanager.del();
+    console.log(`Deleted minikube to reset exited with code ${code}`);
+
+    // The desired Kubernetes version might have changed
+    k8smanager = newK8sManager(cfg.kubernetes);
+
+    await k8smanager.start();
   } catch (ex) {
     handleFailure(ex);
   }

--- a/background.js
+++ b/background.js
@@ -132,7 +132,7 @@ ipcMain.on('k8s-reset', async (event, arg) => {
   }
 });
 
-ipcMain.on('k8s-restart', async (event) => {
+ipcMain.on('k8s-restart', async () => {
   try {
     switch (k8smanager.state) {
       case K8s.State.STOPPED:

--- a/src/components/K8s.vue
+++ b/src/components/K8s.vue
@@ -4,7 +4,7 @@
       <option v-for="item in versions" :key="item" :value="item">{{ item }}</option>
     </select> Kubernetes version
     <hr>
-    <button @click="reset" :disabled="isDisabled" class="role-destructive btn-sm" :class="{ 'btn-disabled': isDisabled }">Reset Kubernetes</button>
+    <button @click="reset" :disabled="cannotReset" class="role-destructive btn-sm" :class="{ 'btn-disabled': cannotReset }">Reset Kubernetes</button>
     Resetting Kubernetes to default will delete all workloads and configuration
     <hr>
     <Checkbox :label="'link to /usr/local/bin/kubectl'"
@@ -48,23 +48,20 @@ export default {
   },
 
   computed: {
-    isDisabled: function() {
-      if (this.state != K8s.State.STARTED) {
-            return true;
-      }
-      return false;
+    cannotReset: function() {
+      return (this.state !== K8s.State.STARTED && this.state !== K8s.State.READY);
     }
   }, 
 
   methods: {
     // Reset a Kubernetes cluster to default at the same version
     reset() {
-      ipcRenderer.send('k8s-reset', 'Reset Kubernetes to default');
       this.state = K8s.State.STOPPING;
+      ipcRenderer.send('k8s-reset', 'Reset Kubernetes to default');
     },
     restart() {
-      ipcRenderer.send('k8s-restart', 'Restart Kubernetes');
       this.state = K8s.State.STOPPING;
+      ipcRenderer.send('k8s-restart', 'Restart Kubernetes');
     },
     onChange(event) {
       if (event.target.value != this.settings.kubernetes.version) {

--- a/src/components/K8s.vue
+++ b/src/components/K8s.vue
@@ -104,16 +104,6 @@ export default {
     });
     ipcRenderer.send('install-state', 'kubectl');
     ipcRenderer.send('install-state', 'helm');
-
-    if (this.state != K8s.State.STARTED) {
-      let tmr = setInterval(() => {
-        let stt = ipcRenderer.sendSync('k8s-state');
-        if (stt === K8s.State.STARTED) {
-          this.state = stt;
-          clearInterval(tmr);
-        }
-      }, 5000)
-    }
   },
 }
 </script>

--- a/src/k8s-engine/client.js
+++ b/src/k8s-engine/client.js
@@ -1,0 +1,72 @@
+'use strict';
+
+// This file contains wrappers to interact with the installed Kubernetes cluster
+
+const net = require("net");
+const k8s = require("@kubernetes/client-node");
+
+/**
+ * KubeClient is a Kubernetes client that will _only_ manage the cluster we spin
+ * up internally.  The user should call initialize() once the cluster has been
+ * created.
+ */
+class KubeClient {
+    #kubeconfig = new k8s.KubeConfig();
+    /**
+     * @type k8s.PortForward?
+     */
+    #forwarder = null;
+    /**
+     * @type net.Server?
+     */
+    #server = null;
+
+    /**
+     * initialize the KubeClient so that we are ready to talk to it.
+     */
+    initialize() {
+        this.#server?.close();
+        this.#server = null;
+        this.#kubeconfig.loadFromDefault();
+        this.#kubeconfig.currentContext = 'rancher-desktop';
+        this.#forwarder = new k8s.PortForward(this.#kubeconfig, true);
+    }
+
+    /**
+     * @type k8s.CoreV1Api
+     */
+    get #coreV1API() {
+        return this.#_coreV1API ||= this.#kubeconfig.makeApiClient(k8s.CoreV1Api);
+    }
+    #_coreV1API = null;
+
+    /**
+     * The port that homestead is forwarded on.  If unavailable, then a new port
+     * forward will automatically be created, listening on localhost.
+     */
+    async homesteadPort() {
+        if (!this.#server) {
+            const namespace = "cattle-system";
+            // Find a pod for homestead
+            let { body } = await this.#coreV1API.listNamespacedPod(namespace, undefined, undefined, undefined, undefined, "app=homestead", 1);
+            let podName = body.items[0].metadata.name;
+            // Set up the port forwarding server
+            let server = net.createServer((socket) => {
+                this.#forwarder.portForward(namespace, podName, [8443], socket, null, socket);
+            });
+            // Start listening, and block until the listener has been established.
+            await new Promise((resolve, reject) => {
+                let done = false;
+                server.once('listening', () => { if (!done) resolve(); done = true; });
+                server.once('error', (error) => { if (!done) reject(error); done = true; });
+                server.listen({ port: 0, host: "localhost" });
+            });
+            this.#server = server;
+        }
+        /** @type net.AddressInfo */
+        let address = this.#server.address();
+        return address.port;
+    }
+}
+
+module.exports = { KubeClient };

--- a/src/k8s-engine/homestead.js
+++ b/src/k8s-engine/homestead.js
@@ -2,21 +2,33 @@
 
 const Helm  = require('./helm.js');
 
-// This function ensures that homestead is running in a cluster
-// TODO: Handle upgrading homestead
-async function ensure() {
+/**
+ * The port that we're listening on (on localhost), which is port-forwarded to
+ * the homestead pod.
+ * @type {number}
+ */
+let homesteadPort = null;
+
+/**
+ * Ensure that homestead is running in a cluster.
+ * TODO: Handle upgrading homestead.
+ * @param {KubeClient} client Connection to Kubernetes (only for port forwarding).
+ */
+async function ensure(client) {
+  const namespace = "cattle-system";
+  const releaseName = "homestead";
   // Check if cluster available
   // Check if homestead is running
   let out;
   try {
-    await Helm.list('cattle-system');
+    await Helm.list(namespace);
   } catch (e) {
     // Can't connect to the cluster so there is a problem.
     throw new Error(`Unable to connect to cluster ${e}`);
   }
 
   try {
-    out = await Helm.status('homestead', 'cattle-system');
+    out = await Helm.status(releaseName, namespace);
   } catch(e) {
     // Couldn't connect to cluster so throw error
     if (e.includes("Kubernetes cluster unreachable")) {
@@ -25,13 +37,20 @@ async function ensure() {
 
     // Homestead isn't installed so install it.
     try {
-      out = await Helm.install('homestead', './resources/homestead-0.0.1.tgz', 'cattle-system', true);
+      out = await Helm.install(releaseName, './resources/homestead-0.0.1.tgz', namespace, true);
     } catch (e2) {
       throw new Error(`Unable to install homestead: ${e2}`);
     }
   }
 
+  // Set up port forwarding, without actually using it.
+  homesteadPort = await client.forwardPort(namespace, "homestead", 8443);
+  console.log(`Homestead port forward is ready on ${homesteadPort}`);
   return out;
 }
 
-exports.ensure = ensure;
+function getPort() {
+  return homesteadPort;
+}
+
+module.exports = { ensure, getPort };

--- a/src/k8s-engine/k8s.js
+++ b/src/k8s-engine/k8s.js
@@ -2,6 +2,7 @@
 
 const { Minikube } = require('./minikube.js')
 const { OSNotImplemented } = require('./notimplemented.js')
+const { KubeClient } = require('./client');
 const os = require('os')
 
 const State = {
@@ -26,3 +27,4 @@ function factory(cfg) {
 
 exports.State = State;
 exports.factory = factory;
+exports.Client = KubeClient;

--- a/src/k8s-engine/k8s.js
+++ b/src/k8s-engine/k8s.js
@@ -6,11 +6,12 @@ const { KubeClient } = require('./client');
 const os = require('os')
 
 const State = {
-  STOPPED: 0,
-  STARTING: 1,
-  STARTED: 2,
-  STOPPING: 3,
-  ERROR: 4,
+  STOPPED: 0,  // The engine is not running.
+  STARTING: 1, // The engine is attempting to start.
+  STARTED: 2,  // The engine is started; the dashboard is not yet ready.
+  READY: 3,    // The engine is started, and the dashboard is ready.
+  STOPPING: 4, // The engine is attempting to stop.
+  ERROR: 5,    // There is an error and we cannot recover automatically.
 }
 
 Object.freeze(State);

--- a/src/k8s-engine/minikube.js
+++ b/src/k8s-engine/minikube.js
@@ -15,7 +15,7 @@ const { EventEmitter } = require('events');
 const process = require('process');
 const { spawn } = require('child_process');
 const os = require('os');
-const path = require('path');
+const pathlib = require('path');
 const fs = require('fs');
 const util = require('util');
 const K8s = require('./k8s.js');
@@ -298,7 +298,7 @@ exports.Minikube = Minikube;
  */
 async function startAgain(obj) {
   const sudo = util.promisify(require('sudo-prompt').exec);
-  const filePath = path.join(paths.data(), ".minikube", "bin", "docker-machine-driver-hyperkit");
+  const filePath = pathlib.join(paths.data(), ".minikube", "bin", "docker-machine-driver-hyperkit");
   const command = `sh -c 'chown root:wheel "${filePath}" && chmod u+s "${filePath}"'`;
   const options = { name: 'Rancher Desktop' };
   await sudo(command, options);

--- a/src/k8s-engine/minikube.js
+++ b/src/k8s-engine/minikube.js
@@ -52,6 +52,11 @@ class Minikube extends EventEmitter {
     return this.#state;
   }
 
+/**
+ * Start the Kubernetes cluster.
+ * @param {boolean} nested Internal use only, do not specify.
+ * @returns {Promise<undefined>}
+ */
   async start(nested = false) {
 
     while (!nested && this.#currentType != undefined) {
@@ -110,8 +115,8 @@ class Minikube extends EventEmitter {
             // TODO: perms modal
             // TODO: Handle non-macos cases. This can be changed when multiple
             // hypervisors are used.
-            let resp = await startAgain(that).catch((err) => { reject(err) });
-            resolve(resp);
+            await startAgain(that).catch(reject);
+            resolve();
             return;
           }
 
@@ -128,10 +133,10 @@ class Minikube extends EventEmitter {
           if (code === 0) {
             that.#state = K8s.State.STARTED;
             that.#client.initialize();
-            resolve(code);
+            resolve();
           } else if (sig === 'SIGINT') {
             that.#state = K8s.State.STOPPED;
-            resolve(0);
+            resolve();
           } else {
             that.#state = K8s.State.ERROR;
             let fixedErrorMessage = customizeMinikubeMessage(errorMessage);

--- a/src/k8s-engine/minikube.js
+++ b/src/k8s-engine/minikube.js
@@ -168,7 +168,7 @@ class Minikube extends EventEmitter {
     // Ensure homestead is running
     console.log("starting homestead");
     try {
-      await Homestead.ensure();
+      await Homestead.ensure(this.#client);
     } catch (e) {
       console.log(`Error starting homestead: ${e}`);
       this.#state = K8s.State.ERROR;
@@ -281,7 +281,13 @@ class Minikube extends EventEmitter {
   }
 
   async homesteadPort() {
-    return await this.#client.homesteadPort();
+    for (; ;) {
+      let port = Homestead.getPort();
+      if (port !== null) {
+        return port;
+      }
+      await sleep(500);
+    }
   }
 }
 

--- a/src/k8s-engine/minikube.js
+++ b/src/k8s-engine/minikube.js
@@ -37,6 +37,9 @@ class Minikube extends EventEmitter {
   // The backing field for #state
   #internalState = K8s.State.STOPPED;
 
+  // #client is a Kubernetes client connected to the internal cluster.
+  #client = new K8s.Client();
+
   // #current holds the current in process job.
   #current
   #currentType
@@ -124,6 +127,7 @@ class Minikube extends EventEmitter {
           // Run the callback function.
           if (code === 0) {
             that.#state = K8s.State.STARTED;
+            that.#client.initialize();
             resolve(code);
           } else if (sig === 'SIGINT') {
             that.#state = K8s.State.STOPPED;
@@ -249,6 +253,10 @@ class Minikube extends EventEmitter {
   clear() {
     this.#current = undefined;
     this.#currentType = undefined;
+  }
+
+  async homesteadPort() {
+    return await this.#client.homesteadPort();
   }
 }
 

--- a/src/k8s-engine/notimplemented.js
+++ b/src/k8s-engine/notimplemented.js
@@ -13,7 +13,7 @@ class OSNotImplemented {
   }
 
   get state() {
-    return State.STOPPED;
+    return State.ERROR;
   }
 
   start() {

--- a/src/menu/tray.js
+++ b/src/menu/tray.js
@@ -69,6 +69,7 @@ function k8sStateChanged(state) {
     [State.STOPPED]: 'Kubernetes is stopped',
     [State.STARTING]: 'Kubernetes is starting',
     [State.STARTED]: 'Kubernetes is running',
+    [State.READY]: 'Kubernetes is ready',
     [State.STOPPING]: 'Kubernetes is shutting down',
     [State.ERROR]: 'Kubernetes has encountered an error',
   }
@@ -76,7 +77,7 @@ function k8sStateChanged(state) {
   let icon = resources.get('icons/kubernetes-icon-black.png');
   let logo = resources.get('icons/logo-square-bw.png');
 
-  if (state == State.STARTED) {
+  if (state === State.STARTED || state === State.READY) {
     icon = resources.get('/icons/kubernetes-icon-color.png');
     logo = resources.get('/icons/logo-square.png');
     // Update the contexts as a new kubernetes context will be added
@@ -92,7 +93,7 @@ function k8sStateChanged(state) {
   stateMenu.label = labels[state] || labels[State.ERROR];
   stateMenu.icon = icon;
 
-  contextMenuItems.find((item) => item.id === 'dashboard').enabled = (state === State.STARTED);
+  contextMenuItems.find((item) => item.id === 'dashboard').enabled = (state === State.READY);
 
   let contextMenu = Menu.buildFromTemplate(contextMenuItems);
   trayMenu.setContextMenu(contextMenu);

--- a/src/menu/tray.js
+++ b/src/menu/tray.js
@@ -15,16 +15,22 @@ const resources = require('../resources');
 let trayMenu = null
 
 let contextMenuItems = [
-  { label: 'Kubernetes is starting',
+  {
+    id: 'state',
+    label: 'Kubernetes is starting',
     type: 'normal',
     icon: resources.get('icons/kubernetes-icon-black.png'),
   },
   { type: 'separator' },
-  { label: 'Preferences',
+  {
+    id: 'preferences',
+    label: 'Preferences',
     type: 'normal',
     click: clicked,
   },
-  { label: 'Kubernetes Contexts',
+  {
+    id: 'contexts',
+    label: 'Kubernetes Contexts',
     type: 'submenu',
     submenu: [],
   },
@@ -82,8 +88,9 @@ function k8sStateChanged(state) {
     logo = resources.get('/icons/logo-square-red.png');
   }
 
-  contextMenuItems[0].label = labels[state] || labels[State.ERROR];
-  contextMenuItems[0].icon = icon;
+  let stateMenu = contextMenuItems.find((item) => item.id === 'state');
+  stateMenu.label = labels[state] || labels[State.ERROR];
+  stateMenu.icon = icon;
 
   let contextMenu = Menu.buildFromTemplate(contextMenuItems);
   trayMenu.setContextMenu(contextMenu);
@@ -97,22 +104,20 @@ function updateContexts() {
   const kc = new k8s.KubeConfig();
   kc.loadFromDefault();
 
-  contextMenuItems[3].submenu = [];
-
+  let contextsMenu = contextMenuItems.find((item) => item.id === 'contexts');
   const curr = kc.getCurrentContext();
 
   const cxts = kc.getContexts();
 
   if (cxts.length === 0) {
-    contextMenuItems[3].submenu.push({label: "None found"});
+    contextsMenu.submenu = [{ label: "None found" }];
   } else {
-    cxts.forEach((val) => {
-      let n = {label: val.name, type: 'checkbox', click: contextClick};
-      if (n.label == curr) {
-        n.checked = true;
-      }
-      contextMenuItems[3].submenu.push(n);
-    })
+    contextsMenu.submenu = cxts.map((val) => ({
+      label: val.name,
+      type: 'checkbox',
+      click: contextClick,
+      checked: (val.name === curr),
+    }));
   }
 
 }

--- a/src/menu/tray.js
+++ b/src/menu/tray.js
@@ -4,7 +4,6 @@
 // lower right on Windows).
 
 const { app, Tray, Menu } = require('electron');
-const window = require('../window/window.js');
 const kubectl = require('../k8s-engine/kubectl.js');
 const kubeconfig = require('../config/kubeconfig.js');
 const k8s = require('@kubernetes/client-node');
@@ -26,7 +25,13 @@ let contextMenuItems = [
     id: 'preferences',
     label: 'Preferences',
     type: 'normal',
-    click: clicked,
+    click: () => app.emit('window-preferences'),
+  },
+  {
+    id: 'dashboard',
+    label: 'Dashboard',
+    type: 'normal',
+    click: () => app.emit('window-dashboard'),
   },
   {
     id: 'contexts',
@@ -40,11 +45,6 @@ let contextMenuItems = [
     type: 'normal'
   }
 ]
-
-async function clicked() {
-  window.openPreferences();
-  app.dock.show();
-}
 
 function init() {
   trayMenu = new Tray(resources.get('icons/logo-square-bw.png'));
@@ -91,6 +91,8 @@ function k8sStateChanged(state) {
   let stateMenu = contextMenuItems.find((item) => item.id === 'state');
   stateMenu.label = labels[state] || labels[State.ERROR];
   stateMenu.icon = icon;
+
+  contextMenuItems.find((item) => item.id === 'dashboard').enabled = (state === State.STARTED);
 
   let contextMenu = Menu.buildFromTemplate(contextMenuItems);
   trayMenu.setContextMenu(contextMenu);

--- a/src/menu/tray.js
+++ b/src/menu/tray.js
@@ -42,7 +42,7 @@ let contextMenuItems = [
 ]
 
 async function clicked() {
-  window.createWindow();
+  window.openPreferences();
   app.dock.show();
 }
 

--- a/src/window/window.js
+++ b/src/window/window.js
@@ -69,12 +69,15 @@ app.on('certificate-error', (event, webContents, url, error, cert, callback) => 
 });
 
 /**
- * Send a message to the renderer process.
+ * Send a message to all windows in the renderer process.
  * @param {string} channel The channel to send on.
  * @param  {...any} args Any arguments to pass.
  */
 function send(channel, ...args) {
-  window.webContents.send(channel, ...args);
+  for (let windowId of Object.values(windowMapping)) {
+    let window = BrowserWindow.fromId(windowId);
+    window?.webContents?.send(channel, ...args);
+  }
 }
 
 module.exports = { openPreferences, openDashboard, send };

--- a/src/window/window.js
+++ b/src/window/window.js
@@ -53,7 +53,7 @@ function openDashboard(port) {
 // from the dashboard window.  This is necessary as the dashboard we run
 // internally uses a self-signed certificate.
 app.on('certificate-error', (event, webContents, url, error, cert, callback) => {
-  console.log(`Certificate error on ${url}`);
+  console.log(`Certificate error on ${url} from issuer ${cert?.issuerCert?.fingerprint || cert?.issuerName}`);
   if (!('dashboard' in windowMapping)) {
     console.log(`... No contents (${webContents}) or mapping (${JSON.stringify(windowMapping)}), skipping.`);
     return;

--- a/src/window/window.js
+++ b/src/window/window.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { BrowserWindow } = require('electron');
+const { app, BrowserWindow } = require('electron');
 
 /**
  * A mapping of window key (which is our own construct) to a window ID (which is
@@ -41,6 +41,34 @@ function openPreferences() {
 }
 
 /**
+ * Open the dashboard window; if it is already open, focus it.
+ * @param {number} port The port that the dashboard is listening on; it is
+ *                      expected to be available on localhost.
+ */
+function openDashboard(port) {
+  createWindow('dashboard', `https://localhost:${port}/`, { sandbox: true });
+}
+
+// Set up a certificate error handler to ignore any certificate errors coming
+// from the dashboard window.  This is necessary as the dashboard we run
+// internally uses a self-signed certificate.
+app.on('certificate-error', (event, webContents, url, error, cert, callback) => {
+  console.log(`Certificate error on ${url}`);
+  if (!('dashboard' in windowMapping)) {
+    console.log(`... No contents (${webContents}) or mapping (${JSON.stringify(windowMapping)}), skipping.`);
+    return;
+  }
+  if (webContents !== BrowserWindow.fromId(windowMapping.dashboard)?.webContents) {
+    console.log(`... Incorrect web contents from ${BrowserWindow.fromId(windowMapping.dashboard)?.webContents}, skipping.`);
+    return;
+  }
+  console.log(`... Accepted.`);
+  // Ignore certificate errors for the dashboard window
+  event.preventDefault();
+  callback(true);
+});
+
+/**
  * Send a message to the renderer process.
  * @param {string} channel The channel to send on.
  * @param  {...any} args Any arguments to pass.
@@ -49,4 +77,4 @@ function send(channel, ...args) {
   window.webContents.send(channel, ...args);
 }
 
-module.exports = { openPreferences, send };
+module.exports = { openPreferences, openDashboard, send };

--- a/src/window/window.js
+++ b/src/window/window.js
@@ -49,6 +49,16 @@ function openDashboard(port) {
   createWindow('dashboard', `https://localhost:${port}/`, { sandbox: true });
 }
 
+/**
+ * Close the dashboard window, if it is already open.
+ */
+function closeDashboard() {
+  if (!('dashboard' in windowMapping)) {
+    return;
+  }
+  BrowserWindow.fromId(windowMapping.dashboard)?.close();
+}
+
 // Set up a certificate error handler to ignore any certificate errors coming
 // from the dashboard window.  This is necessary as the dashboard we run
 // internally uses a self-signed certificate.
@@ -80,4 +90,4 @@ function send(channel, ...args) {
   }
 }
 
-module.exports = { openPreferences, openDashboard, send };
+module.exports = { openPreferences, openDashboard, closeDashboard, send };


### PR DESCRIPTION
This adds a menu item to open the rancher dashboard (i.e. `cattle-system` service `homestead`).  This sets up a port forwarding via the main node process.

Note that while the dashboard loads, it appears to be rather non-functional at the moment.

Fixes #8.