### PR TITLE
Improve `npm run dev` speed

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -11,7 +11,9 @@ jobs:
     - uses: actions/checkout@v2
       with:
         persist-credentials: false
-    - uses: actions/setup-node@v1
+    - uses: actions/setup-node@v2
+      with:
+        node-version: '14.x'
     - run: npm ci
     - run: npm run lint
     - run: node node_modules/.bin/eslint .

--- a/vue.config.js
+++ b/vue.config.js
@@ -32,7 +32,7 @@ module.exports = {
           .use('babel')
           .loader('babel-loader')
           .options({
-            presets: ['@vue/cli-plugin-babel/preset'],
+            presets: [['@babel/preset-env', { targets: { node: 'current' } }]],
             plugins: ['@babel/plugin-proposal-private-methods']
           });
       },

--- a/vue.config.js
+++ b/vue.config.js
@@ -29,6 +29,9 @@ module.exports = {
         config.module
           .rule('babel')
           .test(/\.js$/)
+          .exclude
+          .add(/node_modules/)
+          .end()
           .use('babel')
           .loader('babel-loader')
           .options({


### PR DESCRIPTION
This speeds up invocations of `npm run dev`, from ~50s to ~11s.  Fixes #51.