### PR TITLE
Install pre-requisites before running `npm ci` in github actions

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -14,6 +14,7 @@ jobs:
     - uses: actions/setup-node@v2
       with:
         node-version: '14.x'
+    - run: sudo apt-get install -y libcairo2-dev libpango1.0-dev libpng-dev libjpeg-dev libgif-dev librsvg2-dev
     - run: npm ci
     - run: npm run lint
     - run: node node_modules/.bin/eslint .

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -14,6 +14,7 @@ jobs:
     - uses: actions/setup-node@v2
       with:
         node-version: '14.x'
+    - run: brew install pkg-config cairo pango libpng jpeg giflib librsvg
     - run: npm ci
     - run: npm run electron:build -- --mac --publish=never
     - uses: actions/upload-artifact@v2

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -14,7 +14,14 @@ jobs:
     - uses: actions/setup-node@v2
       with:
         node-version: '14.x'
-    - run: brew install pkg-config cairo pango libpng jpeg giflib librsvg
+    # Separate 'brew install's because one line fails with an unspecified exit code of 1
+    - run: brew install pkg-config
+    - run: brew install cairo
+    - run: brew install pango
+    - run: brew install libpng
+    - run: brew install jpeg
+    - run: brew install giflib
+    - run: brew install librsvg
     - run: npm ci
     - run: npm run electron:build -- --mac --publish=never
     - uses: actions/upload-artifact@v2


### PR DESCRIPTION
The reason for the separate `brew install` lines in package.yaml is that having them all in one line repeatedly gave an unexplained error code 1 and the check failed.