### PR TITLE
Fix issue with homestead launching

### DIFF
--- a/src/k8s-engine/homestead.js
+++ b/src/k8s-engine/homestead.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const resources = require('../resources');
+
 const Helm  = require('./helm.js');
 
 /**
@@ -37,7 +39,7 @@ async function ensure(client) {
 
     // Homestead isn't installed so install it.
     try {
-      out = await Helm.install(releaseName, './resources/homestead-0.0.1.tgz', namespace, true);
+      out = await Helm.install(releaseName, resources.get('homestead-0.0.1.tgz'), namespace, true);
     } catch (e2) {
       throw new Error(`Unable to install homestead: ${e2}`);
     }


### PR DESCRIPTION
I found this while testing the factor reset functionality. RD would not come back up all the way because it could not find the chart to install.