### PR TITLE
48 set minikube memory allocation and number cpus

### DIFF
--- a/pull.sh
+++ b/pull.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env
+
+set -x
+
+npm install "eslint@>=7.5.0"
+npm install "bufferutil@^4.0.1"
+npm install "utf-8-validate@^5.0.2"
+npm install "vue@^2.x"
+npm install "vue-template-compiler@^2.x"
+npm install "vue-template-compiler@^2.0.0"
+npm install "canvas@^2.5.0"
+npm install "sass@^1.3.0"
+npm install "fibers@>= 3.1.0"
+npm install "bufferutil@^4.0.1"
+npm install "utf-8-validate@^5.0.2"

--- a/src/components/K8s.vue
+++ b/src/components/K8s.vue
@@ -229,9 +229,6 @@ export default {
     ipcRenderer.on('k8s-check-state', function(event, stt) {
       that.$data.state = stt;
     })
-    ipcRenderer.on('settings-update', (event, settings) => {
-      this.$data.settings = settings;
-    })
     ipcRenderer.on('install-state', (event, name, state) => {
       console.log(`install state changed for ${name}: ${state}`);
       this.$data.symlinks[name] = state;

--- a/src/components/K8s.vue
+++ b/src/components/K8s.vue
@@ -8,15 +8,8 @@
     Resetting Kubernetes to default will delete all workloads and configuration
     <hr>
     <p>Minikube Settings:</p>
-    <div class="minikube-settings">
-      <MinikubeMemory :memory_in_gb="settings.minikube.allocations.memory_in_gb"
-                      @input="updatedMemory"/>
-    </div>
-    <div>
-      <p v-if="memoryValueIsntValid" class="bad-input">
-        Invalid value: {{ invalidMemoryValueReason }}
-      </p>
-    </div>
+    <MinikubeMemory :memory_in_gb="settings.minikube.allocations.memory_in_gb"
+                    @input="updatedMemory"/>
     <p>Supporting Utilities:</p>
     <Checkbox :label="'link to /usr/local/bin/kubectl'"
               :disabled="symlinks.kubectl === null"

--- a/src/components/K8s.vue
+++ b/src/components/K8s.vue
@@ -75,7 +75,7 @@ export default {
         if (value === "") {
           return "No value provided";
         }
-        if (!/^\d+(?:\.\d*)?$/.test(value)) {
+        if (!/^-?\d+(?:\.\d*)?$/.test(value)) {
           return "Contains non-numeric characters";
         }
       }
@@ -138,7 +138,8 @@ export default {
     } else {
       this.availMemoryInGB = totalMemInGB - minGBForNonMinikubeStuff;
     }
-      this.availNumCPUs = os.cpus.length; // do we need to reserve one or two?
+      this.availNumCPUs = os.cpus().length; // do we need to reserve one or two?
+
   },
 
   methods: {

--- a/src/components/K8s.vue
+++ b/src/components/K8s.vue
@@ -7,16 +7,13 @@
     <button @click="reset" :disabled="cannotReset" class="role-destructive btn-sm" :class="{ 'btn-disabled': cannotReset }">Reset Kubernetes</button>
     Resetting Kubernetes to default will delete all workloads and configuration
     <hr>
-    <div class="minikube-settings">
     <MinikubeMemory :memoryInGB="settings.minikube.allocations.memoryInGB"
                     :numberCPUs="settings.minikube.allocations.numberCPUs"
                     :availMemoryInGB = "availMemoryInGB"
                     :availNumCPUs="availNumCPUs"
                     @updateMemory="handleUpdateMemory"
                     @updateCPU="handleUpdateCPU"
-                    @input="ignoreInputEvent"
                     />
-    </div>
     <p>Supporting Utilities:</p>
     <Checkbox :label="'link to /usr/local/bin/kubectl'"
               :disabled="symlinks.kubectl === null"
@@ -100,7 +97,7 @@ export default {
       return !this.memoryValueIsValid;
     },
     invalidNumCPUsValueReason: function() {
-      let value = this.settings.numberCPUs;
+      let value = this.settings.minikube.allocations.numberCPUs;
       let numericValue;
       if (typeof (value) === "string") {
         numericValue = parseFloat(value);
@@ -239,13 +236,5 @@ export default {
 .select-k8s-version {
   width: inherit;
   display: inline-block;
-}
-
-p.bad-input {
-  border: red 1px solid;
-}
-
-div.minikube-settings {
-  width: 15em;
 }
 </style>

--- a/src/components/K8s.vue
+++ b/src/components/K8s.vue
@@ -196,10 +196,6 @@ export default {
         this.debouncedActOnUpdateCPUs();
       }
     },
-    ignoreInputEvent(event) {
-      //TODO: We shouldn't need this method
-      console.log(`***: ignoring input event ${event}`);
-    },
     actOnUpdatedMemory() {
       if (this.memoryValueIsValid) {
         ipcRenderer.invoke('settings-write', {

--- a/src/components/K8s.vue
+++ b/src/components/K8s.vue
@@ -173,11 +173,7 @@ export default {
     handleCheckbox(event, name) {
       ipcRenderer.send('install-set', name, event.target.checked);
     },
-    // handleUpdateMinikubeSetting(type, value) {
-    //   console.log(`QQQ: handleUpdateMemory(type:${type}, value:${value})`);
-    // },
     handleUpdateMemory(event) {
-      console.log(`QQQ: handleUpdateMemory in k8s.vue (value:${event && event.target.value})`);
       if (!event) {
         alert("awp - handleUpdateMemory has no event");
         return;
@@ -189,7 +185,6 @@ export default {
       }
     },
     handleUpdateCPU(event) {
-      console.log(`QQQ: handleUpdateCPU in k8s.vue (value:${event && event.target.value})`);
       if (!event) {
         alert("awp - handleUpdateCPU has no event");
         return;
@@ -197,12 +192,12 @@ export default {
       let value = event.target.value;
       this.settings.minikube.allocations.numberCPUs = parseInt(value, 10);
       if (this.numCPUsValueIsValid) {
-        console.log(`QQQ - debouncedActOnUpdateCPUs`)
         this.debouncedActOnUpdateCPUs();
       }
     },
     ignoreInputEvent(event) {
-      console.log(`QQQ: ignoring input event ${event}`);
+      //TODO: We shouldn't need this method
+      console.log(`***: ignoring input event ${event}`);
     },
     actOnUpdatedMemory() {
       if (this.memoryValueIsValid) {
@@ -216,7 +211,6 @@ export default {
       }
     },
     actOnUpdatedCPUs() {
-      console.log(`QQQ: >> actOnUpdatedCPUs, is valid: ${this.numCPUsValueIsValid}`)
       if (this.numCPUsValueIsValid) {
         ipcRenderer.invoke('settings-write', {
           minikube: {
@@ -224,8 +218,6 @@ export default {
               numberCPUs: this.settings.minikube.allocations.numberCPUs
             }
           }
-        }).then(() => {
-          console.log(`QQQ: Update CPUS to ${this.settings.minikube.allocations.numberCPUs} succeeded`)
         })
       }
     },

--- a/src/components/MinikubeMemory.vue
+++ b/src/components/MinikubeMemory.vue
@@ -4,6 +4,7 @@
     components: {
       LabeledInput
     },
+/*
       data() {
           return {
               settings: {
@@ -12,6 +13,7 @@
               }
           }
       },
+*/
     props: {
       memoryInGB: {
         type: String,
@@ -30,64 +32,9 @@
             default: 0
         }
     },
-      computed: {
-    invalidMemoryValueReason: function() {
-      let value = this.settings.memoryInGB;
-      // This might not work due to floating-point inaccuracies,
-      // but testing showed it works for up to 3 decimal points.
-      if (value === "") {
-        return "No value provided";
-      }
-      if (!/^\d+(?:\.\d*)?$/.test(value)) {
-        return "Contains non-numeric characters";
-      }
-      let numericValue = parseFloat(value);
-      if (isNaN(numericValue)) {
-        return `${value} isnt numeric`
-      }
-      if (numericValue < 2) {
-        return "Specified value is too low, must be at least 2 (GB)";
-      }
-      if (numericValue > this.availMemoryInGB && this.availMemoryInGB) {
-        let etre = this.availMemoryInGB == 1 ? "is" : "are";
-        return `Specified value is too high, only ${this.availMemoryInGB} GB ${etre} available`;
-      }
-      return '';
-    },
-
-    memoryValueIsValid: function() {
-      return !this.invalidMemoryValueReason;
-    },
-    memoryValueIsntValid: function() {
-      return !this.memoryValueIsValid;
-    },
-    invalidNumCPUsValueReason: function() {
-      let value = this.settings.numberCPUs;
-      let numericValue = parseFloat(value);
-      if (isNaN(numericValue)) {
-        return `${value} isnt numeric`
-      }
-      if (numericValue < 2) {
-        return "Specified value is too low, must be at least 2 (GB)";
-      }
-      if (numericValue > this.availNumCPUs && this.availNumCPUs) {
-        const pluralSuffix = this.availNumCPUs == 1 ? "" : "s";
-        const isVerb = this.availNumCPUs == 1 ? "is" : "are";
-        return `Specified value is too high, only ${this.availNumCPUs} CPU${pluralSuffix} ${isVerb} available`;
-      }
-      return '';
-    },
-
-    numCPUsValueIsValid: function() {
-      return !this.invalidNumCPUsValueReason;
-    },
-    numCPUsValueIsntValid: function() {
-      return !this.numCPUsValueIsValid;
-    },
-      },
       methods: {
           updatedMemory(event) {
-            // this.settings.memoryInGB = event.target.value;
+            //this.settings.memoryInGB = event.target.value;
             try {
               if (typeof(event) === "string") {
                 // TODO: Why does this happen?
@@ -114,6 +61,82 @@
             }
           }
       },
+    computed: {
+
+      invalidMemoryValueReason: function() {
+        console.log(`QQQ: >>> minikube invalidMemoryValueReason`);
+        let value = this.memoryInGB;
+        // This might not work due to floating-point inaccuracies,
+        // but testing showed it works for up to 3 decimal points.
+        if (value === "") {
+          console.log(`QQQ: <<< false`);
+          return "No value provided";
+        }
+        if (!/^-?\d+(?:\.\d*)?$/.test(value)) {
+          console.log(`QQQ: <<< false`);
+          return "Contains non-numeric characters";
+        }
+        let numericValue = parseFloat(value);
+        if (isNaN(numericValue)) {
+          console.log(`QQQ: <<< false`);
+          return `${value} isnt numeric`
+        }
+        if (numericValue < 2) {
+          console.log(`QQQ: <<< false`);
+          return "Specified value is too low, must be at least 2 (GB)";
+        }
+        if (numericValue > this.availMemoryInGB && this.availMemoryInGB) {
+          let etre = this.availMemoryInGB == 1 ? "is" : "are";
+          console.log(`QQQ: <<< false`);
+          return `Specified value is too high, only ${this.availMemoryInGB} GB ${etre} available`;
+        }
+        console.log(`QQQ: <<< true`);
+        return '';
+      },
+
+      memoryValueIsValid: function() {
+        console.log(`QQQ: >>> minikube memoryValueIsValid`);
+        console.log(`QQQ: <<< ${!this.invalidMemoryValueReason}`);
+        return !this.invalidMemoryValueReason;
+      },
+      memoryValueIsntValid: function() {
+        console.log(`QQQ: >>> minikube memoryValueIsntValid`);
+        console.log(`QQQ: <<< ${!this.memoryValueIsntValid}`);
+        return !this.memoryValueIsValid;
+      },
+      invalidNumCPUsValueReason: function() {
+        console.log(`QQQ: >>> minikube invalidNumCPUsValueReason`);
+        let value = this.numberCPUs;
+        let numericValue = parseFloat(value);
+        if (isNaN(numericValue)) {
+          console.log(`QQQ: <<< false`);
+          return `${value} isnt numeric`
+        }
+        if (numericValue < 2) {
+          console.log(`QQQ: <<< false`);
+          return "Specified value is too low, must be at least 2 (GB)";
+        }
+        if (numericValue > this.availNumCPUs && this.availNumCPUs) {
+          console.log(`QQQ: <<< false`);
+          const pluralSuffix = this.availNumCPUs == 1 ? "" : "s";
+          const isVerb = this.availNumCPUs == 1 ? "is" : "are";
+          return `Specified value is too high, only ${this.availNumCPUs} CPU${pluralSuffix} ${isVerb} available`;
+        }
+        console.log(`QQQ: <<< true`);
+        return '';
+      },
+
+      numCPUsValueIsValid: function() {
+        console.log(`QQQ: >>> minikube numCPUsValueIsValid`);
+        console.log(`QQQ: <<< ${!this.invalidNumCPUsValueReason}`);
+        return !this.invalidNumCPUsValueReason;
+      },
+      numCPUsValueIsntValid: function() {
+        console.log(`QQQ: >>> minikube numCPUsValueIsntValid`);
+        console.log(`QQQ: <<< ${!this.numCPUsValueIsValid}`);
+        return !this.numCPUsValueIsValid;
+      },
+    }
   }
 </script>
 

--- a/src/components/MinikubeMemory.vue
+++ b/src/components/MinikubeMemory.vue
@@ -89,27 +89,28 @@
           updatedMemory(event) {
             // this.settings.memoryInGB = event.target.value;
             try {
-              if (typeof(event) === "string") return;
-              console.log(`QQQ: handling memory in Minikube, value=${event?.target?.value}`)
+              if (typeof(event) === "string") {
+                // TODO: Why does this happen?
+                return;
+              }
               this.$emit('updateMemory', event);
               event.preventDefault();
               event.stopPropagation();
-              console.log(`QQQ: + $emit updateMemory`);
             } catch(e) {
-              console.log(`QQQ: error in updatedMemory:${e}`)
+              console.log(`error in updatedMemory:${e}`)
             }
           },
           updatedCPU(event) {
             try {
-              if (typeof(event) === "string") return;
-              // this.settings.numberCPUs = event.target.value;
-              console.log(`QQQ: handling CPU in Minikube, value=${event?.target?.value}`)
+              if (typeof(event) === "string") {
+                // TODO: Why does this happen?
+                return;
+              }
               this.$emit('updateCPU', event);
               event.preventDefault();
               event.stopPropagation();
-              console.log(`QQQ: + $emit updateCPU`);
             } catch(e) {
-              console.log(`QQQ: error in updatedMemory:${e}`)
+              console.log(`error in updatedMemory:${e}`)
             }
           }
       },

--- a/src/components/MinikubeMemory.vue
+++ b/src/components/MinikubeMemory.vue
@@ -63,8 +63,6 @@
     },
     invalidNumCPUsValueReason: function() {
       let value = this.settings.numberCPUs;
-      // This might not work due to floating-point inaccuracies,
-      // but testing showed it works for up to 3 decimal points.
       let numericValue = parseFloat(value);
       if (isNaN(numericValue)) {
         return `${value} isnt numeric`
@@ -89,16 +87,30 @@
       },
       methods: {
           updatedMemory(event) {
-              this.settings.memoryInGB = event.target.value;
-              if (this.memoryValueIsValid) {
-                  this.$emit('input', 'memoryInGB', this.settings.memoryInGB);
-              }
+            // this.settings.memoryInGB = event.target.value;
+            try {
+              if (typeof(event) === "string") return;
+              console.log(`QQQ: handling memory in Minikube, value=${event?.target?.value}`)
+              this.$emit('updateMemory', event);
+              event.preventDefault();
+              event.stopPropagation();
+              console.log(`QQQ: + $emit updateMemory`);
+            } catch(e) {
+              console.log(`QQQ: error in updatedMemory:${e}`)
+            }
           },
           updatedCPU(event) {
-              this.settings.numberCPUs = event.target.value;
-              if (this.cpuValueIsValid) {
-                  this.$emit('input', 'numberCPUs', this.settings.numberCPUs);
-              }
+            try {
+              if (typeof(event) === "string") return;
+              // this.settings.numberCPUs = event.target.value;
+              console.log(`QQQ: handling CPU in Minikube, value=${event?.target?.value}`)
+              this.$emit('updateCPU', event);
+              event.preventDefault();
+              event.stopPropagation();
+              console.log(`QQQ: + $emit updateCPU`);
+            } catch(e) {
+              console.log(`QQQ: error in updatedMemory:${e}`)
+            }
           }
       },
   }
@@ -111,6 +123,7 @@
       <LabeledInput
         :value="memoryInGB"
         label="memory in GB"
+        @input="updatedMemory"
         />
       <div>
         <p v-if="memoryValueIsntValid" class="bad-input">
@@ -124,6 +137,7 @@
         :value="numberCPUs"
         type="number"
         label="number of CPUs"
+        @input="updatedCPU"
       />
       <div>
         <p v-if="numCPUsValueIsntValid" class="bad-input">

--- a/src/components/MinikubeMemory.vue
+++ b/src/components/MinikubeMemory.vue
@@ -111,7 +111,7 @@
 </script>
 
 <template>
-  <div>
+  <div class="minikube-settings">
     <p>Minikube Settings:</p>
     <div id="memoryInGBWrapper">
       <LabeledInput
@@ -141,3 +141,21 @@
     </div>
   </div>
 </template>
+
+<style scoped>
+
+div.minikube-settings div.labeled-input {
+    width: 15em;
+    margin-bottom: 5pt;
+}
+
+div.minikube-settings p.bad-input {
+  border: red 1px dotted;
+  width: 40em;
+    overflow: visible;
+    font-size: 11pt;
+    margin-top: -4pt;
+    margin-bottom: 5pt;
+}
+
+</style>

--- a/src/components/MinikubeMemory.vue
+++ b/src/components/MinikubeMemory.vue
@@ -4,21 +4,132 @@
     components: {
       LabeledInput
     },
+      data() {
+          return {
+              settings: {
+                  memoryInGB: this.memoryInGB,
+                  numberCPUs: this.numberCPUs
+              }
+          }
+      },
     props: {
-      memory_in_gb: {
+      memoryInGB: {
         type: String,
-        default: "1"
-      }
+        default: "2"
+      },
+      numberCPUs: {
+        type: Number,
+        default: 2
+      },
+        availMemoryInGB: {
+            type: Number,
+            default: 0
+        },
+        availNumCPUs: {
+            type: Number,
+            default: 0
+        }
     },
-    // emits: ['input']
+      computed: {
+    invalidMemoryValueReason: function() {
+      let value = this.settings.memoryInGB;
+      // This might not work due to floating-point inaccuracies,
+      // but testing showed it works for up to 3 decimal points.
+      if (value === "") {
+        return "No value provided";
+      }
+      if (!/^\d+(?:\.\d*)?$/.test(value)) {
+        return "Contains non-numeric characters";
+      }
+      let numericValue = parseFloat(value);
+      if (isNaN(numericValue)) {
+        return `${value} isnt numeric`
+      }
+      if (numericValue < 2) {
+        return "Specified value is too low, must be at least 2 (GB)";
+      }
+      if (numericValue > this.availMemoryInGB && this.availMemoryInGB) {
+        let etre = this.availMemoryInGB == 1 ? "is" : "are";
+        return `Specified value is too high, only ${this.availMemoryInGB} GB ${etre} available`;
+      }
+      return '';
+    },
+
+    memoryValueIsValid: function() {
+      return !this.invalidMemoryValueReason;
+    },
+    memoryValueIsntValid: function() {
+      return !this.memoryValueIsValid;
+    },
+    invalidNumCPUsValueReason: function() {
+      let value = this.settings.numberCPUs;
+      // This might not work due to floating-point inaccuracies,
+      // but testing showed it works for up to 3 decimal points.
+      let numericValue = parseFloat(value);
+      if (isNaN(numericValue)) {
+        return `${value} isnt numeric`
+      }
+      if (numericValue < 2) {
+        return "Specified value is too low, must be at least 2 (GB)";
+      }
+      if (numericValue > this.availNumCPUs && this.availNumCPUs) {
+        const pluralSuffix = this.availNumCPUs == 1 ? "" : "s";
+        const isVerb = this.availNumCPUs == 1 ? "is" : "are";
+        return `Specified value is too high, only ${this.availNumCPUs} CPU${pluralSuffix} ${isVerb} available`;
+      }
+      return '';
+    },
+
+    numCPUsValueIsValid: function() {
+      return !this.invalidNumCPUsValueReason;
+    },
+    numCPUsValueIsntValid: function() {
+      return !this.numCPUsValueIsValid;
+    },
+      },
+      methods: {
+          updatedMemory(event) {
+              this.settings.memoryInGB = event.target.value;
+              if (this.memoryValueIsValid) {
+                  this.$emit('input', 'memoryInGB', this.settings.memoryInGB);
+              }
+          },
+          updatedCPU(event) {
+              this.settings.numberCPUs = event.target.value;
+              if (this.cpuValueIsValid) {
+                  this.$emit('input', 'numberCPUs', this.settings.numberCPUs);
+              }
+          }
+      },
   }
 </script>
 
 <template>
   <div>
-    <LabeledInput
-      :value="memory_in_gb"
-      label="memory in GB"
+    <p>Minikube Settings:</p>
+    <div id="memoryInGBWrapper">
+      <LabeledInput
+        :value="memoryInGB"
+        label="memory in GB"
+        />
+      <div>
+        <p v-if="memoryValueIsntValid" class="bad-input">
+          Invalid value: {{ invalidMemoryValueReason }}
+        </p>
+      </div>
+    </div>
+
+    <div id="numCPUWrapper">
+      <LabeledInput
+        :value="numberCPUs"
+        type="number"
+        label="number of CPUs"
       />
+      <div>
+        <p v-if="numCPUsValueIsntValid" class="bad-input">
+          Invalid value: {{ invalidNumCPUsValueReason }}
+        </p>
+      </div>
+    </div>
   </div>
 </template>

--- a/src/components/MinikubeMemory.vue
+++ b/src/components/MinikubeMemory.vue
@@ -4,16 +4,6 @@
     components: {
       LabeledInput
     },
-/*
-      data() {
-          return {
-              settings: {
-                  memoryInGB: this.memoryInGB,
-                  numberCPUs: this.numberCPUs
-              }
-          }
-      },
-*/
     props: {
       memoryInGB: {
         type: String,
@@ -64,76 +54,56 @@
     computed: {
 
       invalidMemoryValueReason: function() {
-        console.log(`QQQ: >>> minikube invalidMemoryValueReason`);
         let value = this.memoryInGB;
         // This might not work due to floating-point inaccuracies,
         // but testing showed it works for up to 3 decimal points.
         if (value === "") {
-          console.log(`QQQ: <<< false`);
           return "No value provided";
         }
         if (!/^-?\d+(?:\.\d*)?$/.test(value)) {
-          console.log(`QQQ: <<< false`);
           return "Contains non-numeric characters";
         }
         let numericValue = parseFloat(value);
         if (isNaN(numericValue)) {
-          console.log(`QQQ: <<< false`);
           return `${value} isnt numeric`
         }
         if (numericValue < 2) {
-          console.log(`QQQ: <<< false`);
           return "Specified value is too low, must be at least 2 (GB)";
         }
         if (numericValue > this.availMemoryInGB && this.availMemoryInGB) {
           let etre = this.availMemoryInGB == 1 ? "is" : "are";
-          console.log(`QQQ: <<< false`);
           return `Specified value is too high, only ${this.availMemoryInGB} GB ${etre} available`;
         }
-        console.log(`QQQ: <<< true`);
         return '';
       },
 
       memoryValueIsValid: function() {
-        console.log(`QQQ: >>> minikube memoryValueIsValid`);
-        console.log(`QQQ: <<< ${!this.invalidMemoryValueReason}`);
         return !this.invalidMemoryValueReason;
       },
       memoryValueIsntValid: function() {
-        console.log(`QQQ: >>> minikube memoryValueIsntValid`);
-        console.log(`QQQ: <<< ${!this.memoryValueIsntValid}`);
         return !this.memoryValueIsValid;
       },
       invalidNumCPUsValueReason: function() {
-        console.log(`QQQ: >>> minikube invalidNumCPUsValueReason`);
         let value = this.numberCPUs;
         let numericValue = parseFloat(value);
         if (isNaN(numericValue)) {
-          console.log(`QQQ: <<< false`);
           return `${value} isnt numeric`
         }
         if (numericValue < 2) {
-          console.log(`QQQ: <<< false`);
           return "Specified value is too low, must be at least 2 (GB)";
         }
         if (numericValue > this.availNumCPUs && this.availNumCPUs) {
-          console.log(`QQQ: <<< false`);
           const pluralSuffix = this.availNumCPUs == 1 ? "" : "s";
           const isVerb = this.availNumCPUs == 1 ? "is" : "are";
           return `Specified value is too high, only ${this.availNumCPUs} CPU${pluralSuffix} ${isVerb} available`;
         }
-        console.log(`QQQ: <<< true`);
         return '';
       },
 
       numCPUsValueIsValid: function() {
-        console.log(`QQQ: >>> minikube numCPUsValueIsValid`);
-        console.log(`QQQ: <<< ${!this.invalidNumCPUsValueReason}`);
         return !this.invalidNumCPUsValueReason;
       },
       numCPUsValueIsntValid: function() {
-        console.log(`QQQ: >>> minikube numCPUsValueIsntValid`);
-        console.log(`QQQ: <<< ${!this.numCPUsValueIsValid}`);
         return !this.numCPUsValueIsValid;
       },
     }

--- a/src/components/__tests__/MinikubeMemory.spec.js
+++ b/src/components/__tests__/MinikubeMemory.spec.js
@@ -25,15 +25,4 @@ describe('MinikubeMemory.vue', () => {
     // for details.
     expect(wrapper.html()).toMatch(/<label>memory in GB.*<input.*type="text"/)
   })
-
-  it("can parseFloat small numbers accurately", () => {
-    let base = Math.floor(1000 * Math.random()) + 1;
-    let baseStr = base.toString();
-    for (let i = 0; i < 1000; i++) {
-      let str1 = baseStr + "." + i.toString().padStart(3, "0");
-      let str2 = parseFloat(str1).toString();
-      let str1Fixed = str1.replace(/0+$/, "").replace(/\.$/, '');
-      expect(str1Fixed).toEqual(str2);
-    }
-  })
 })

--- a/src/components/__tests__/MinikubeMemory.spec.js
+++ b/src/components/__tests__/MinikubeMemory.spec.js
@@ -1,6 +1,6 @@
 import { mount } from '@vue/test-utils'
 import MinikubeMemory from '../MinikubeMemory.vue'
-// const deepmerge = require('deepmerge');
+import merge from 'lodash/merge';
 
 class ShadowRootShadowClass {
   // Because the code's not a browser there is no ShadowRoot
@@ -8,21 +8,132 @@ class ShadowRootShadowClass {
   // See node_modules/@vue/runtime-dom/dist/runtime-dom.cjs.js:1260 for context
 }
 
+function safeMerge(baseProps, overrides) {
+  let newProps = {};
+  merge(newProps, baseProps, overrides);
+  return newProps;
+}
 function createWrappedPage(props) {
   return mount(MinikubeMemory, { props: props });
 }
+
+function createWrappedPageGetErrorMessages(props) {
+  const wrapper = createWrappedPage(props);
+  const memoryErrorMessage =  wrapper.find("div#memoryInGBWrapper p.bad-input");
+  const cpuErrorMessage = wrapper.find("div#numCPUWrapper p.bad-input");
+  return [memoryErrorMessage, cpuErrorMessage];
+}
+
+const baseProps = {
+  memoryInGB: '4',
+  numberCPUs: 4,
+  availMemoryInGB: 8,
+  availNumCPUs: 6
+};
 
 describe('MinikubeMemory.vue', () => {
   beforeAll(() => {
     global.ShadowRoot = ShadowRootShadowClass;
   })
 
-  it('formats the props correctly', () => {
-    const wrapper = createWrappedPage( { memory_in_gb: '37' });
-    expect(wrapper.props().memory_in_gb).toBe('37');
+  it("accepts valid data", async () => {
+    const wrapper = createWrappedPage(baseProps);
+
+    expect(wrapper.props().memoryInGB).toBe('4');
+    expect(wrapper.props().numberCPUs).toBe(4);
+    expect(wrapper.props().availMemoryInGB).toBe(8);
+    expect(wrapper.props().availNumCPUs).toBe(6);
+
     // Don't test against the actual value field. See
     // https://stackoverflow.com/questions/65710738/why-is-the-value-attribute-not-showing-up-when-i-test-this-vue3-component
     // for details.
-    expect(wrapper.html()).toMatch(/<label>memory in GB.*<input.*type="text"/)
+    expect(wrapper.html()).toMatch(/<label>memory in GB.*<input.*type="text"/);
+    expect(wrapper.html()).toMatch(/<label>number of CPUs.*<input.*type="number"/);
+    let div1 =  wrapper.find("div#memoryInGBWrapper");
+    expect(div1.find("p.bad-input").exists()).toBe(false);
+    let div2 = wrapper.find("div#numCPUWrapper");
+    expect(div2.find("p.bad-input").exists()).toBe(false);
+  });
+
+  it("sets correct defaults", () => {
+    let minimalProps = safeMerge(baseProps, {});
+    delete minimalProps.memoryInGB;
+    delete minimalProps.numberCPUs;
+    const wrapper = createWrappedPage(minimalProps);
+    expect(wrapper.props().memoryInGB).toBe('2');
+    expect(wrapper.props().numberCPUs).toBe(2);
   })
+
+  it ('complains about invalid memory', () => {
+    let newProps = safeMerge(baseProps, {memoryInGB: '37abc'} );
+    const [memoryErrorMessage, cpuErrorMessage] = createWrappedPageGetErrorMessages(newProps);
+
+    expect(memoryErrorMessage.exists()).toBe(true);
+    expect(memoryErrorMessage.text()).toContain("Contains non-numeric characters");
+
+    expect(cpuErrorMessage.exists()).toBe(false);
+  });
+
+  it ('complains about oversize memory', () => {
+    let newProps = safeMerge(baseProps, {memoryInGB: '55', availMemoryInGB: 54} );
+    const [memoryErrorMessage, cpuErrorMessage] = createWrappedPageGetErrorMessages(newProps);
+
+    expect(memoryErrorMessage.exists()).toBe(true);
+    expect(memoryErrorMessage.text()).toContain("Specified value is too high, only 54 GB are available");
+
+    expect(cpuErrorMessage.exists()).toBe(false);
+  });
+
+  it ('complains about oversize memory with singular case', () => {
+    let newProps = safeMerge(baseProps, {memoryInGB: '55', availMemoryInGB: 1} );
+    const [memoryErrorMessage, cpuErrorMessage] = createWrappedPageGetErrorMessages(newProps);
+
+    expect(memoryErrorMessage.exists()).toBe(true);
+    expect(memoryErrorMessage.text()).toContain("Specified value is too high, only 1 GB is available");
+
+    expect(cpuErrorMessage.exists()).toBe(false);
+  });
+
+  it ('complains about missing memory value', () => {
+    let newProps = safeMerge(baseProps, {memoryInGB: ''} );
+    const [memoryErrorMessage, cpuErrorMessage] = createWrappedPageGetErrorMessages(newProps);
+
+    expect(memoryErrorMessage.exists()).toBe(true);
+    expect(memoryErrorMessage.text()).toContain("No value provided");
+
+    expect(cpuErrorMessage.exists()).toBe(false);
+  });
+
+  it ('complains about not enough CPUs', () => {
+    let newProps = safeMerge(baseProps, {} );
+    [-1, 0, 1].forEach((numCPUs) => {
+      newProps.numberCPUs = numCPUs;
+      let [memoryErrorMessage, cpuErrorMessage] = createWrappedPageGetErrorMessages(newProps);
+
+      expect(memoryErrorMessage.exists()).toBe(false);
+
+      expect(cpuErrorMessage.exists()).toBe(true);
+      expect(cpuErrorMessage.text()).toContain("Invalid value: Specified value is too low, must be at least 2 (GB)");
+    })
+  });
+
+  it ('complains about too many size CPUs', () => {
+    let newProps = safeMerge(baseProps, {numberCPUs: 55, availNumCPUs: 54} );
+    const [memoryErrorMessage, cpuErrorMessage] = createWrappedPageGetErrorMessages(newProps);
+
+    expect(memoryErrorMessage.exists()).toBe(false);
+
+    expect(cpuErrorMessage.exists()).toBe(true);
+    expect(cpuErrorMessage.text()).toContain("Specified value is too high, only 54 CPUs are available");
+  });
+
+  it ('complains about too many CPUs with singular case', () => {
+    let newProps = safeMerge(baseProps, {numberCPUs: 55, availNumCPUs: 1} );
+    const [memoryErrorMessage, cpuErrorMessage] = createWrappedPageGetErrorMessages(newProps);
+
+    expect(memoryErrorMessage.exists()).toBe(false);
+
+    expect(cpuErrorMessage.exists()).toBe(true);
+    expect(cpuErrorMessage.text()).toContain("Specified value is too high, only 1 CPU is available");
+  });
 })

--- a/src/config/settings.js
+++ b/src/config/settings.js
@@ -29,7 +29,8 @@ const defaultSettings = {
   },
   minikube: {
     allocations: {
-      memory_in_gb: "2"
+      memoryInGB: "2",
+      numberCPUs: 2,
     }
   }
 }

--- a/src/k8s-engine/minikube.js
+++ b/src/k8s-engine/minikube.js
@@ -109,9 +109,9 @@ class Minikube extends EventEmitter {
       // TODO: Handle the difference between changing version where a wipe is needed
       // and upgrading. All if there was a change.
       args.push("--kubernetes-version=" + this.cfg.kubernetes.version);
-      let memory_in_gb = this.cfg.minikube?.allocations?.memory_in_gb;
-      if (memory_in_gb != 2) {
-        args.push(`--memory=${memory_in_gb}g`);
+      let memoryInGB = this.cfg.minikube?.allocations?.memoryInGB;
+      if (memoryInGB != 2) {
+        args.push(`--memory=${memoryInGB}g`);
       }
       const bat = spawn(resources.executable('minikube'), args, opts);
       this.#current = bat;


### PR DESCRIPTION
Note that this branch - to add the #-CPU field -- is based on branch 47-add-memory-setting, not `main`.

The unit tests are now actually exercising the validation and presence & content or absence of the error-message field. 

I still haven't figured out how to mock event-handlers in vue-test/jest, but that will be worth doing. Docs are there, but somewhat sparse. Picked the lower-hanging fruit to get this far.