### PR TITLE
Making installing homestead optional

### DIFF
--- a/background.js
+++ b/background.js
@@ -33,6 +33,7 @@ app.whenReady().then(() => {
 
   cfg = settings.init();
   console.log(cfg);
+  tray.emit("settings-update", cfg);
   k8smanager = newK8sManager(cfg.kubernetes);
 
   k8smanager.start().catch(handleFailure);
@@ -106,6 +107,7 @@ ipcMain.handle('settings-write', async (event, arg) => {
   settings.save(cfg);
   event.sender.sendToFrame(event.frameId, 'settings-update', cfg);
   k8smanager?.emit("settings-update", cfg);
+  tray?.emit("settings-update", cfg);
 });
 
 ipcMain.on('k8s-state', (event) => {

--- a/background.js
+++ b/background.js
@@ -105,6 +105,7 @@ ipcMain.handle('settings-write', async (event, arg) => {
   cfg = deepmerge(cfg, arg);
   settings.save(cfg);
   event.sender.sendToFrame(event.frameId, 'settings-update', cfg);
+  k8smanager?.emit("settings-update", cfg);
 });
 
 ipcMain.on('k8s-state', (event) => {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
       "node": true
     },
     "extends": [
-      "plugin:vue/vue3-essential",
+      "plugin:vue/essential",
       "eslint:recommended"
     ],
     "parserOptions": {

--- a/src/components/form/RadioButton.vue
+++ b/src/components/form/RadioButton.vue
@@ -1,0 +1,177 @@
+<script>
+import { _VIEW } from '@/config/query-params';
+export default {
+  props: {
+    // The name of the input, for grouping
+    name: {
+      type:    String,
+      default: ''
+    },
+
+    // The value for this option
+    val: {
+      required:  true,
+      validator: x => true,
+    },
+
+    // The selected value...
+    value: {
+      required:  true,
+      validator: x => true,
+    },
+
+    // The label shown next to the radio
+    label: {
+      type:    String,
+      default: ''
+    },
+
+    disabled: {
+      type:    Boolean,
+      default: false
+    },
+
+    mode: {
+      type:    String,
+      default: 'edit',
+    }
+  },
+
+  data() {
+    return { isChecked: this.value === this.val };
+  },
+
+  computed: {
+    isDisabled() {
+      return this.mode === _VIEW || this.disabled;
+    },
+  },
+
+  watch: {
+    value(neu) {
+      this.isChecked = this.val === neu;
+      if ( this.isChecked ) {
+        this.$refs.custom.focus();
+      }
+    }
+  },
+
+  methods: {
+    clicked(e) {
+      if (this.isDisabled) {
+        return;
+      }
+
+      if (e.srcElement?.tagName === 'A') {
+        return;
+      }
+
+      this.$emit('input', this.val);
+    },
+  }
+};
+</script>
+
+<template>
+  <label
+    class="radio-container"
+    @keydown.enter="clicked($event)"
+    @keydown.space="clicked($event)"
+    @click.stop="clicked($event)"
+  >
+    <input
+      :id="_uid+'-radio'"
+      :disabled="isDisabled"
+      :name="name"
+      :value="''+val"
+      :checked="isChecked"
+      type="radio"
+      :tabindex="-1"
+      @click.stop.prevent
+    />
+    <span
+      ref="custom"
+      :class="[ isDisabled ? 'text-muted' : '', 'radio-custom']"
+      :tabindex="isDisabled ? -1 : 0"
+      :aria-label="label"
+      :aria-checked="isChecked"
+      role="radio"
+    />
+    <label
+      v-if="label"
+      :class="[ isDisabled ? 'text-muted' : '', 'radio-label']"
+      v-html="label"
+    >
+      <slot name="label">{{ label }}</slot>
+    </label>
+  </label>
+</template>
+
+<style lang='scss'>
+.radio-view {
+  display: flex;
+  flex-direction: column;
+  LABEL {
+    color: var(--input-label)
+  }
+}
+
+.radio-group {
+  .text-label {
+    display: block;
+    padding-bottom: 5px;
+  }
+}
+
+.radio-container {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  margin: 0;
+  cursor: pointer;
+  user-select: none;
+  border-radius: var(--border-radius);
+  padding-bottom: 5px;
+
+  .radio-label {
+    margin: 3px 10px 0px 5px;
+  }
+
+ .radio-custom {
+    height: 14px;
+    width: 14px;
+    min-height: 14px;
+    min-width: 14px;
+    background-color: var(--input-bg);
+    border-radius: 50%;
+    transition: all 0.3s ease-out;
+    border: 1.5px solid var(--border);
+
+    &:focus {
+      outline: none;
+      border-radius: 50%;
+    }
+  }
+
+  input {
+    display: none;
+  }
+
+  .radio-custom {
+    &[aria-checked="true"] {
+      background-color: var(--dropdown-text);
+      -webkit-transform: rotate(0deg) scale(1);
+      -ms-transform: rotate(0deg) scale(1);
+      transform: rotate(0deg) scale(1);
+      opacity:1;
+      border: 1.5px solid var(--dropdown-text);
+    }
+  }
+
+  input:disabled ~ .radio-custom:not([aria-checked="true"]) {
+    background-color: var(--disabled-bg);
+    opacity: .25;
+  }
+}
+
+</style>

--- a/src/components/form/RadioButton.vue
+++ b/src/components/form/RadioButton.vue
@@ -11,13 +11,13 @@ export default {
     // The value for this option
     val: {
       required:  true,
-      validator: x => true,
+      validator: () => true,
     },
 
     // The selected value...
     value: {
       required:  true,
-      validator: x => true,
+      validator: () => true,
     },
 
     // The label shown next to the radio

--- a/src/components/form/RadioGroup.vue
+++ b/src/components/form/RadioGroup.vue
@@ -1,0 +1,184 @@
+<script>
+import RadioButton from '@/components/form/RadioButton';
+import { _VIEW } from '@/config/query-params';
+
+export default {
+  components: { RadioButton },
+  props:      {
+    // Name for the checkbox grouping, must be unique on page
+    name: {
+      type:     String,
+      required: true,
+    },
+
+    // Options can be an array of {label, value}, or just values
+    options: {
+      type:     Array,
+      required: true
+    },
+
+    // If options are just values, then labels can be a corresponding display value
+    labels: {
+      type:    Array,
+      default: null,
+    },
+
+    // The selected value
+    value: {
+      type:    [Boolean, String],
+      default: null
+    },
+
+    disabled: {
+      type:    Boolean,
+      default: false
+    },
+
+    mode: {
+      type:    String,
+      default: 'edit'
+    },
+
+    // Label for above the radios
+    label: {
+      type:    String,
+      default: null
+    },
+    labelKey: {
+      type:    String,
+      default: null
+    },
+
+    // Label for above the radios
+    tooltip: {
+      type:    [String, Object],
+      default: null
+    },
+    tooltipKey: {
+      type:    String,
+      default: null
+    },
+
+    // show radio buttons in column or row
+    row: {
+      type:    Boolean,
+      default: false
+    }
+  },
+
+  computed: {
+    normalizedOptions() {
+      const out = [];
+
+      for ( let i = 0 ; i < this.options.length ; i++ ) {
+        const opt = this.options[i];
+
+        if ( typeof opt === 'object' && opt ) {
+          out.push(opt);
+        } else if ( this.labels ) {
+          out.push({
+            label: this.labels[i],
+            value: opt,
+          });
+        } else {
+          out.push({
+            label: opt,
+            value: opt
+          });
+        }
+      }
+
+      return out;
+    },
+
+    isView() {
+      return this.mode === _VIEW;
+    },
+
+    isDisabled() {
+      return (this.disabled || this.isView);
+    }
+  },
+
+  methods: {
+    // keyboard left/right event listener to select next/previous option
+    clickNext(direction) {
+      const opts = this.normalizedOptions;
+      const selected = opts.find(x => x.value === this.value);
+      let newIndex = (selected ? opts.indexOf(selected) : -1 ) + direction;
+
+      if ( newIndex >= opts.length ) {
+        newIndex = opts.length - 1;
+      } else if ( newIndex < 0 ) {
+        newIndex = 0;
+      }
+
+      this.$emit('input', opts[newIndex].value);
+    }
+  }
+};
+</script>
+
+<template>
+  <div>
+    <div v-if="label || labelKey || tooltip || tooltipKey" class="radio-group label">
+      <slot name="label">
+        <h3>
+          <t v-if="labelKey" :k="labelKey" />
+          <template v-else-if="label">
+            {{ label }}
+          </template>
+          <i v-if="tooltipKey" v-tooltip="t(tooltipKey)" class="icon icon-info icon-lg" />
+          <i v-else-if="tooltip" v-tooltip="tooltip" class="icon icon-info icon-lg" />
+        </h3>
+      </slot>
+    </div>
+    <div
+      class="radio-group"
+      :class="{'row':row}"
+      tabindex="0"
+      @keyup.down.stop="clickNext(1)"
+      @keyup.up.stop="clickNext(-1)"
+    >
+      <div
+        v-for="(option, i) in normalizedOptions"
+        :key="name+'-'+i"
+      >
+        <RadioButton
+          :key="name+'-'+i"
+          :name="name"
+          :value="value"
+          :label="option.label"
+          :val="option.value"
+          :disabled="isDisabled"
+          :mode="mode"
+          v-on="$listeners"
+        />
+      </div>
+    </div>
+  </div>
+</template>
+
+<style lang='scss'>
+.radio-group {
+  &:focus {
+    border:none;
+    outline:none;
+  }
+
+  h3 {
+    position: relative;
+  }
+
+  .row {
+    display: flex;
+    .radio-container {
+      margin-right: 10px;
+    }
+  }
+
+  .label{
+    font-size: 14px !important;
+  }
+}
+</style>

--- a/src/components/form/RadioGroup.vue
+++ b/src/components/form/RadioGroup.vue
@@ -170,7 +170,7 @@ export default {
     position: relative;
   }
 
-  .row {
+  &.row {
     display: flex;
     .radio-container {
       margin-right: 10px;

--- a/src/config/settings.js
+++ b/src/config/settings.js
@@ -18,14 +18,21 @@ const isDeepEqual = require('lodash/isEqual');
 
 const CURRENT_SETTINGS_VERSION = 1;
 
+/** @typedef {typeof defaultSettings} Settings */
+
 const defaultSettings = {
   version: CURRENT_SETTINGS_VERSION,
   kubernetes: {
-    version: "v1.19.2"
+    version: "v1.19.2",
+    /** @type { import("../k8s-engine/homestead").State } */
+    rancherMode: "HOMESTEAD",
   }
 }
 
-// Load the settings file
+/**
+ * Load the settings file
+ * @returns {Settings}
+ */
 function load() {
   const rawdata = fs.readFileSync(paths.config() + '/settings.json');
   let settings;
@@ -65,7 +72,10 @@ async function clear() {
   await util.promisify(fs.rm ?? fs.rmdir)(paths.config(), { recursive: true, force: true });
 }
 
-// Load the settings file or create it if not present.
+/**
+ * Load the settings file or create it if not present.
+ * @returns {Settings}
+ */
 function init() {
   let settings = {};
   try {

--- a/src/k8s-engine/client.js
+++ b/src/k8s-engine/client.js
@@ -206,6 +206,14 @@ class KubeClient {
         address ||= this.#server.address();
         return address.port;
     }
+
+    async cancelForwardPort() {
+        let server = this.#server;
+        this.#server = null;
+        if (server) {
+            await new Promise(resolve => server.close(resolve));
+        }
+    }
 }
 
 module.exports = { KubeClient };

--- a/src/k8s-engine/helm.js
+++ b/src/k8s-engine/helm.js
@@ -20,17 +20,17 @@ function exec(options = {}, ...args) {
       }
       args.push(param);
     }
-    const bat = spawn(resources.executable("/bin/helm"), args);
-    let dta = '', err = '';
-    bat.stdout.on('data', data => dta += data.toString());
-    bat.stderr.on('data', data => err += data.toString());
-    bat.on('exit', code => {
+    const childProcess = spawn(resources.executable("/bin/helm"), args);
+    let stdout = '', stderr = '';
+    childProcess.stdout.on('data', data => stdout += data.toString());
+    childProcess.stderr.on('data', data => stderr += data.toString());
+    childProcess.on('exit', code => {
       if (code !== 0) {
-        reject(err);
+        reject(stderr);
       } else if (/^json$/i.test(options?.output)) {
-        resolve(JSON.parse(dta));
+        resolve(JSON.parse(stdout));
       } else {
-        resolve(dta);
+        resolve(stdout);
       }
     });
   });

--- a/src/k8s-engine/homestead.js
+++ b/src/k8s-engine/homestead.js
@@ -4,6 +4,8 @@ const resources = require('../resources');
 
 const Helm  = require('./helm.js');
 
+/** @typedef {import("./client").KubeClient} KubeClient */
+
 /**
  * The port that we're listening on (on localhost), which is port-forwarded to
  * the homestead pod.
@@ -12,47 +14,112 @@ const Helm  = require('./helm.js');
 let homesteadPort = null;
 
 /**
- * Ensure that homestead is running in a cluster.
- * TODO: Handle upgrading homestead.
- * @param {KubeClient} client Connection to Kubernetes (only for port forwarding).
+ * The valid installation states.
+ * @enum {string}
  */
-async function ensure(client) {
+const State = Object.freeze({
+  /** Homestead will not be installed. */
+  NONE: "NONE",
+  /** Homestead will be installed. */
+  HOMESTEAD: "HOMESTEAD",
+  // TODO: add state for full Rancher
+});
+
+/**
+ * The desired state for Rancher on the cluster; this may not match current
+ * state if we have pending operations.
+ * @type {State}
+ */
+let desiredState = State.NONE;
+
+/**
+ * Ensure that the homestead chart is installed on the cluster.
+ * @param {State} state Whether the homestead chart should be installed.
+ * @returns {Promise<boolean>} True if no changes were made.
+ */
+async function ensureHelmChart(state) {
   const namespace = "cattle-system";
   const releaseName = "homestead";
-  // Check if cluster available
-  // Check if homestead is running
-  let out;
+  let actualState = State.NONE;
   try {
-    await Helm.list(namespace);
+    let list = await Helm.list(namespace);
+    let entry = list.find((entry) => {
+      return entry?.namespace === namespace && entry?.name === releaseName;
+    });
+    actualState = (entry?.status === 'deployed') ? State.HOMESTEAD : State.NONE;
   } catch (e) {
-    // Can't connect to the cluster so there is a problem.
-    throw new Error(`Unable to connect to cluster ${e}`);
+    throw new Error(`Unable to connect to cluster: ${e}`);
+  }
+  if (actualState == state) {
+    return true;
   }
 
-  try {
-    out = await Helm.status(releaseName, namespace);
-  } catch(e) {
-    // Couldn't connect to cluster so throw error
-    if (e.includes("Kubernetes cluster unreachable")) {
-      throw new Error(`Unable to connect to cluster ${e}`);
+  switch (state) {
+    case State.NONE: {
+      await Helm.uninstall(releaseName, namespace);
+      break;
     }
-
-    // Homestead isn't installed so install it.
-    try {
-      out = await Helm.install(releaseName, resources.get('homestead-0.0.1.tgz'), namespace, true);
-    } catch (e2) {
-      throw new Error(`Unable to install homestead: ${e2}`);
+    case State.HOMESTEAD: {
+      try {
+        await Helm.install(releaseName, resources.get('homestead-0.0.1.tgz'), namespace, true);
+      } catch (e) {
+        throw new Error(`Unable to install homestead: ${e}`);
+      }
+      break;
     }
   }
 
-  // Set up port forwarding, without actually using it.
-  homesteadPort = await client.forwardPort(namespace, "homestead", 8443);
-  console.log(`Homestead port forward is ready on ${homesteadPort}`);
-  return out;
+  return false;
+}
+
+/**
+ * Ensure that port forwarding is set up correctly for the homestead chart.
+ * @param {State} state Whether we want port forwarding to be set up.
+ * @param {KubeClient} client Connection to Kubernetes for port forwarding.
+ */
+async function ensurePortForwarding(state, client) {
+  const namespace = "cattle-system";
+  switch (state) {
+    case State.NONE:
+      await client.cancelForwardPort(namespace, "homestead", 8443);
+      homesteadPort = null;
+      break;
+    case State.HOMESTEAD:
+      homesteadPort = await client.forwardPort(namespace, "homestead", 8443);
+      console.log(`Homestead port forward is ready on ${homesteadPort}`);
+      break;
+  }
+  return true;
+}
+
+/**
+ * Ensure that homestead is installed on the cluster if desired, otherwise it is
+ * uninstalled.  Note that the state after returning from this function may be
+ * different from the state passed in, if this is being invoked multiple times
+ * concurrently.
+ * @param {State} state The desired installation state to reach.
+ * @param {KubeClient} client Connection to Kubernetes (only for port forwarding).
+ * @returns {Promise<void>}
+ */
+async function ensure(state, client) {
+  // Set a global variable, so that if we end up invoking this function many
+  // times concurrently, we can stablize quickly.
+  desiredState = state;
+
+  let ready = false;
+  while (!ready) {
+    ready = true;
+    if (!await ensureHelmChart(desiredState)) {
+      ready = false;
+    }
+    if (!await ensurePortForwarding(desiredState, client)) {
+      ready = false;
+    }
+  }
 }
 
 function getPort() {
   return homesteadPort;
 }
 
-module.exports = { ensure, getPort };
+module.exports = { State, ensure, getPort };

--- a/src/k8s-engine/homestead.js
+++ b/src/k8s-engine/homestead.js
@@ -55,18 +55,17 @@ async function ensureHelmChart(state) {
   }
 
   switch (state) {
-    case State.NONE: {
+    case State.NONE:
       await Helm.uninstall(releaseName, namespace);
       break;
-    }
-    case State.HOMESTEAD: {
-      try {
+    case State.HOMESTEAD:
+    default:
+        try {
         await Helm.install(releaseName, resources.get('homestead-0.0.1.tgz'), namespace, true);
       } catch (e) {
         throw new Error(`Unable to install homestead: ${e}`);
       }
       break;
-    }
   }
 
   return false;
@@ -85,6 +84,7 @@ async function ensurePortForwarding(state, client) {
       homesteadPort = null;
       break;
     case State.HOMESTEAD:
+    default:
       homesteadPort = await client.forwardPort(namespace, "homestead", 8443);
       console.log(`Homestead port forward is ready on ${homesteadPort}`);
       break;

--- a/src/k8s-engine/minikube.js
+++ b/src/k8s-engine/minikube.js
@@ -315,6 +315,10 @@ class Minikube extends EventEmitter {
   async #installRancher() {
     // Ensure homestead is running
     console.log("starting homestead");
+    if (this.#state === K8s.State.READY) {
+      // Mark this as not quite ready yet.
+      this.#state = K8s.State.STARTED;
+    }
     let mode = this.cfg?.rancherMode ?? "HOMESTEAD";
     try {
       await Homestead.ensure(mode, this.#client);

--- a/src/k8s-engine/minikube.js
+++ b/src/k8s-engine/minikube.js
@@ -314,7 +314,7 @@ class Minikube extends EventEmitter {
     // Ensure homestead is running
     console.log("starting homestead");
     try {
-      await Homestead.ensure(this.#client);
+      await Homestead.ensure(Homestead.State.HOMESTEAD, this.#client);
     } catch (e) {
       console.log(`Error starting homestead: ${e}`);
       this.#state = K8s.State.ERROR;

--- a/src/k8s-engine/minikube.js
+++ b/src/k8s-engine/minikube.js
@@ -175,18 +175,7 @@ class Minikube extends EventEmitter {
     this.#state = K8s.State.STARTED;
     this.#client = new K8s.Client();
 
-    // Ensure homestead is running
-    console.log("starting homestead");
-    try {
-      await Homestead.ensure(this.#client);
-    } catch (e) {
-      console.log(`Error starting homestead: ${e}`);
-      this.#state = K8s.State.ERROR;
-      throw { context: "installing homestead", errorCode: 1, message: `Error starting homestead` };
-    }
-
-    console.log(`Everything is ready.`);
-    this.#state = K8s.State.READY;
+    await this.#installRancher();
   }
 
   async stop() {
@@ -316,6 +305,24 @@ class Minikube extends EventEmitter {
     await this.del();
     // fs.rm does not yet exist in the version of node we pull in from electron
     await util.promisify(fs.rm ?? fs.rmdir)(paths.data(), { recursive: true, force: true });
+  }
+
+  /**
+   * Install Rancher / homestead.
+   */
+  async #installRancher() {
+    // Ensure homestead is running
+    console.log("starting homestead");
+    try {
+      await Homestead.ensure(this.#client);
+    } catch (e) {
+      console.log(`Error starting homestead: ${e}`);
+      this.#state = K8s.State.ERROR;
+      throw { context: "installing homestead", errorCode: 1, message: `Error starting homestead` };
+    }
+
+    console.log(`Everything is ready.`);
+    this.#state = K8s.State.READY;
   }
 }
 

--- a/src/k8s-engine/minikube.js
+++ b/src/k8s-engine/minikube.js
@@ -319,7 +319,7 @@ class Minikube extends EventEmitter {
       // Mark this as not quite ready yet.
       this.#state = K8s.State.STARTED;
     }
-    let mode = this.cfg?.rancherMode ?? "HOMESTEAD";
+    let mode = this.cfg?.rancherMode || "HOMESTEAD";
     try {
       await Homestead.ensure(mode, this.#client);
     } catch (e) {

--- a/vue.config.js
+++ b/vue.config.js
@@ -35,7 +35,7 @@ module.exports = {
           .use('babel')
           .loader('babel-loader')
           .options({
-            presets: [['@babel/preset-env', { targets: { node: 'current' } }]],
+            presets: [['@babel/preset-env', { targets: { node: 10 } }]],
             plugins: ['@babel/plugin-proposal-private-methods']
           });
       },


### PR DESCRIPTION
This makes it optional to install homestead (though it's still on by default).  It might make sense to review commit-by-commit rather than as a large diff.

This will help with #38 but will not fix it completely — we still need the ability to install full rancher.

If we take this, we can have follow-up PRs for:
- Cleaning up `helm.js`, since the wrapper function should be able to handle most of the repeated logic.
- Installing full rancher (non-homestead).