### PR TITLE
Stricter linting

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -3,4 +3,4 @@ module.exports = {
     '@vue/cli-plugin-babel/preset'
   ],
   plugins: ["@babel/plugin-proposal-private-methods"]
-}
+};

--- a/background.js
+++ b/background.js
@@ -26,7 +26,7 @@ app.whenReady().then(() => {
 
   tray = new Tray();
   tray.on('window-preferences', () => { window.openPreferences(); app.dock.show(); });
-  tray.on('window-dashboard', async () => { window.openDashboard(await k8smanager.homesteadPort()) });
+  tray.on('window-dashboard', async () => { window.openDashboard(await k8smanager.homesteadPort()); });
 
   // TODO: Check if first install and start welcome screen
   // TODO: Check if new version and provide window with details on changes
@@ -42,7 +42,7 @@ app.whenReady().then(() => {
   // file:// URLs for our resources.
   protocol.registerFileProtocol('app', (request, callback) => {
     let relPath = (new URL(request.url)).pathname;
-    relPath = decodeURI(relPath) // Needed in case URL contains spaces
+    relPath = decodeURI(relPath); // Needed in case URL contains spaces
     // Default to the path for development mode, running out of the source tree.
     let result = { path: path.join(app.getAppPath(), ".webpack", relPath) };
     if (app.isPackaged) {
@@ -62,7 +62,7 @@ app.whenReady().then(() => {
     callback(result);
   });
   window.openPreferences();
-})
+});
 
 let gone = false;
 app.on('before-quit', (event) => {
@@ -80,7 +80,7 @@ app.on('before-quit', (event) => {
         handleFailure(ex);
       })
     .finally(app.quit);
-})
+});
 
 // TODO: Handle non-darwin OS
 app.on('window-all-closed', () => {
@@ -89,7 +89,7 @@ app.on('window-all-closed', () => {
   if (process.platform !== 'darwin') {
     app.quit();
   }
-})
+});
 
 app.on('activate', () => {
   // On macOS it's common to re-create a window in the app when the
@@ -168,7 +168,7 @@ async function refreshInstallState(name) {
   const linkPath = path.join("/usr/local/bin", name);
   const desiredPath = resources.executable(name);
   let [err, dest] = await new Promise((resolve) => {
-    fs.readlink(linkPath, (err, dest) => { resolve([err, dest]) });
+    fs.readlink(linkPath, (err, dest) => { resolve([err, dest]); });
   });
   console.log(`Reading ${linkPath} got error ${err?.code} result ${dest}`);
   if (err?.code === "ENOENT") {
@@ -197,7 +197,7 @@ ipcMain.on('install-set', async (event, name, newState) => {
     }
   } else {
     if (await refreshInstallState(name)) {
-      let err = new Promise((resolve) => { fs.unlink(linkPath, resolve) });
+      let err = new Promise((resolve) => { fs.unlink(linkPath, resolve); });
       if (err) {
         console.error(`Error unlinking symlink for ${linkPath}`, err);
         event.reply('install-state', name, null);
@@ -206,7 +206,7 @@ ipcMain.on('install-set', async (event, name, newState) => {
       }
     }
   }
-})
+});
 
 /**
  * Do a factory reset of the application.  This will stop the currently running
@@ -235,10 +235,10 @@ function handleFailure(payload) {
   } else {
     errorCode = payload.errorCode;
     message = payload.message;
-    titlePart = payload.context
+    titlePart = payload.context;
   }
-  console.log(`Kubernetes was unable to start with exit code: ${errorCode}`)
-  titlePart = titlePart || "Starting Kubernetes"
+  console.log(`Kubernetes was unable to start with exit code: ${errorCode}`);
+  titlePart = titlePart || "Starting Kubernetes";
   dialog.showErrorBox(`Error ${titlePart}`, message);
 }
 

--- a/package.json
+++ b/package.json
@@ -47,6 +47,9 @@
       "plugin:vue/recommended",
       "eslint:recommended"
     ],
+    "ignorePatterns": [
+      "dist/**"
+    ],
     "parserOptions": {
       "parser": "@babel/eslint-parser"
     },

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
       "node": true
     },
     "extends": [
-      "plugin:vue/vue3-essential",
+      "plugin:vue/recommended",
       "eslint:recommended"
     ],
     "parserOptions": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,9 @@
     "parserOptions": {
       "parser": "@babel/eslint-parser"
     },
-    "rules": {}
+    "rules": {
+      "semi": 2
+    }
   },
   "browserslist": [
     "> 1%",

--- a/scripts/generateReleaseList.js
+++ b/scripts/generateReleaseList.js
@@ -1,12 +1,12 @@
-const { Octokit } = require("@octokit/rest")
-const semverRsort = require('semver/functions/rsort')
-const semver = require('semver')
-const fs = require('fs')
+const { Octokit } = require("@octokit/rest");
+const semverRsort = require('semver/functions/rsort');
+const semver = require('semver');
+const fs = require('fs');
 
 const octokit = new Octokit({
     userAgent: 'mattfarina/rd',
     baseUrl: 'https://api.github.com',
-})
+});
 
 // octokit.request('GET /rate_limit').then(foo => {
 // console.log(foo)
@@ -15,23 +15,23 @@ octokit.paginate(octokit.repos.listReleases, {
     owner: 'kubernetes',
     repo: 'kubernetes',
 }).then(data => {
-    let vers = []
+    let vers = [];
     data.forEach((val) => {
         // Remove prereleases by looking for a -
         if (!val.tag_name.includes('-') && val.tag_name != undefined) {
             if (semver.valid(semver.coerce(val.tag_name))) {
                 if (semver.gte(semver.coerce(val.tag_name), 'v1.13.0')) {
-                    vers.push(val.tag_name)
+                    vers.push(val.tag_name);
                 }
             }
         }
-    })
+    });
 
-    semverRsort(vers, true)
+    semverRsort(vers, true);
 
     try {
-        fs.writeFileSync("./src/generated/versions.json", JSON.stringify(vers))
+        fs.writeFileSync("./src/generated/versions.json", JSON.stringify(vers));
       } catch (err) {
-        console.error(err)
+        console.error(err);
       }
 });

--- a/scripts/hyperkit.js
+++ b/scripts/hyperkit.js
@@ -43,9 +43,9 @@ spawn('git', ['clone', '--depth', '1', '--branch', ver, "https://github.com/moby
       }
       fs.chmod(process.cwd() + '/resources/' + os.platform() + '/hyperkit', 0o755, (err) => {
         if (err != null) {
-          console.error(err)
+          console.error(err);
         }
       });
-    })
-  })
-})
+    });
+  });
+});

--- a/scripts/setupmac.js
+++ b/scripts/setupmac.js
@@ -34,7 +34,7 @@ const file3 = fs.createWriteStream("/tmp/helm-v3.4.1-darwin-amd64.tar.gz");
 https.get("https://get.helm.sh/helm-v3.4.1-darwin-amd64.tar.gz", function(response) {
   response.on('data', (data) => {
     file3.write(data);
-  })
+  });
   response.on('end', () => {
     file3.end();
     spawn('tar', ['-zxvf', '/tmp/helm-v3.4.1-darwin-amd64.tar.gz', '--directory', "/tmp/"]).on('exit', () => {
@@ -43,7 +43,7 @@ https.get("https://get.helm.sh/helm-v3.4.1-darwin-amd64.tar.gz", function(respon
         spawnSync('chmod', ['+x', process.cwd() + '/resources/darwin/bin/helm']);
       }).stderr.on('data', (data) => {
         console.log(data.toString());
-      })
-    })
-  })
-})
+      });
+    });
+  });
+});

--- a/src/App.vue
+++ b/src/App.vue
@@ -29,9 +29,9 @@ export default {
   data() {
     return {
       routes: this.navItems 
-    }
+    };
   },
-}
+};
 </script>
 
 <style lang="scss">

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,8 +1,11 @@
 <template>
   <div class="wrapper">
     <Header class="header" />
-    <Nav class="nav" :items="routes" />
-    <router-view class="body"></router-view>
+    <Nav
+      class="nav"
+      :items="routes"
+    />
+    <router-view class="body" />
   </div>
 </template>
 
@@ -12,10 +15,15 @@ import Nav from './components/Nav.vue';
 
 export default {
   name: 'App',
-  props: ['navItems'],
   components: {
     Nav,
     Header
+  },
+  props: {
+    navItems: {
+      type: Array,
+      required: true,
+    },
   },
 
   data() {

--- a/src/components/Checkbox.vue
+++ b/src/components/Checkbox.vue
@@ -73,16 +73,16 @@ export default {
       type="checkbox"
       :v-model="value"
       @click.stop
-      />
+    >
     <span
       class="checkbox-custom"
       :aria-label="label"
       :aria-checked="!!value"
       role="checkbox"
     />
-    <span class="checkbox-label" >
+    <span class="checkbox-label">
       <slot name="label">
-        <span>{{label}}</span>
+        <span>{{ label }}</span>
       </slot>
     </span>
   </label>

--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -1,7 +1,10 @@
 <template>
   <header>
-    <div alt="Logo" class="logo">
-        <img src="../assets/images/half-logo.svg" />
+    <div
+      alt="Logo"
+      class="logo"
+    >
+      <img src="../assets/images/half-logo.svg">
     </div>
     <h1>Rancher Desktop</h1>
   </header>

--- a/src/components/K8s.vue
+++ b/src/components/K8s.vue
@@ -63,7 +63,7 @@ export default {
         'helm': null,
         'kubectl': null,
       }
-    }
+    };
   },
 
   computed: {
@@ -76,10 +76,10 @@ export default {
     let that = this;
     ipcRenderer.on('k8s-check-state', function(event, stt) {
       that.$data.state = stt;
-    })
+    });
     ipcRenderer.on('settings-update', (event, settings) => {
       this.$data.settings = settings;
-    })
+    });
     ipcRenderer.on('install-state', (event, name, state) => {
       console.log(`install state changed for ${name}: ${state}`);
       this.$data.symlinks[name] = state;
@@ -121,7 +121,7 @@ export default {
       ipcRenderer.send('install-set', name, event.target.checked);
     }
   },
-}
+};
 </script>
 
 <style scoped>

--- a/src/components/Nav.vue
+++ b/src/components/Nav.vue
@@ -22,7 +22,7 @@ export default {
         required: true,
       }
     },
-}
+};
 </script>
 
 <!-- Add "scoped" attribute to limit CSS to this component only -->

--- a/src/components/Nav.vue
+++ b/src/components/Nav.vue
@@ -1,16 +1,27 @@
 <template>
   <nav>
     <ul>
-        <li v-bind:item="item" v-bind:key="item.name" v-for="item in items">
-            <router-link :to="item.path">{{ item.component.title }}</router-link>
-        </li>
+      <li
+        v-for="item in items"
+        :key="item.name"
+        :item="item"
+      >
+        <router-link :to="item.path">
+          {{ item.component.title }}
+        </router-link>
+      </li>
     </ul>
   </nav>
 </template>
 
 <script>
 export default {
-    props: ['items'],
+    props: {
+      items: {
+        type: Array,
+        required: true,
+      }
+    },
 }
 </script>
 

--- a/src/components/Troubleshooting.vue
+++ b/src/components/Troubleshooting.vue
@@ -1,8 +1,13 @@
 <template>
   <div>
-    <button @click="factoryReset" :disabled="!canFactoryReset"
-            class="role-destructive btn-sm"
-            :class="{'btn-disabled': !canFactoryReset}">Factory Reset</button>
+    <button
+      :disabled="!canFactoryReset"
+      class="role-destructive btn-sm"
+      :class="{'btn-disabled': !canFactoryReset}"
+      @click="factoryReset"
+    >
+      Factory Reset
+    </button>
     Factory reset will remove all Rancher Desktop configuration.
   </div>
 </template>
@@ -31,6 +36,11 @@ export default {
       }
     }
   },
+  mounted: function() {
+    ipcRenderer.on('k8s-check-state', (event, newState) => {
+      this.$data.state = newState;
+    });
+  },
   methods: {
     factoryReset() {
       const message = `
@@ -41,11 +51,6 @@ export default {
         ipcRenderer.send('factory-reset');
       }
     }
-  },
-  mounted: function() {
-    ipcRenderer.on('k8s-check-state', (event, newState) => {
-      this.$data.state = newState;
-    });
   }
 }
 </script>

--- a/src/components/Troubleshooting.vue
+++ b/src/components/Troubleshooting.vue
@@ -52,5 +52,5 @@ export default {
       }
     }
   }
-}
+};
 </script>

--- a/src/components/Welcome.vue
+++ b/src/components/Welcome.vue
@@ -10,7 +10,7 @@
 export default {
   name: 'Welcome',
   title: 'Welcome',
-}
+};
 </script>
 
 <!-- Add "scoped" attribute to limit CSS to this component only -->

--- a/src/config/settings.js
+++ b/src/config/settings.js
@@ -27,7 +27,7 @@ const defaultSettings = {
   kubernetes: {
     version: "v1.19.2"
   }
-}
+};
 
 
 function save(cfg, inBrowser) {

--- a/src/k8s-engine/helm.js
+++ b/src/k8s-engine/helm.js
@@ -22,11 +22,11 @@ function list(namespace) {
 
     bat.stdout.on('data', (data) => {
       dta += data.toString();
-    })
+    });
 
     bat.stderr.on('data', (data) => {
       err += data.toString();
-    })
+    });
 
     bat.on('exit', (code) => {
       if (code === 0) {
@@ -34,8 +34,8 @@ function list(namespace) {
       } else {
         reject('Failed to list resource: ' + err);
       }
-    })
-  })
+    });
+  });
 }
 
 /**
@@ -61,11 +61,11 @@ function status(name, namespace) {
 
     bat.stdout.on('data', (data) => {
       dta += data.toString();
-    })
+    });
 
     bat.stderr.on('data', (data) => {
       err += data.toString();
-    })
+    });
 
     bat.on('exit', (code) => {
       if (code === 0) {
@@ -73,7 +73,7 @@ function status(name, namespace) {
       } else {
         reject('Failed to list resource: ' + err);
       }
-    })
+    });
   });
 }
 
@@ -105,15 +105,15 @@ function install(name, chart, namespace, createNamespace) {
     }
 
     // TODO: There is a lot of repeated code in this file. It could be simplified.
-    const bat = spawn(resources.executable('/bin/helm'), args)
+    const bat = spawn(resources.executable('/bin/helm'), args);
 
     bat.stdout.on('data', (data) => {
       dta += data.toString();
-    })
+    });
 
     bat.stderr.on('data', (data) => {
       err += data.toString();
-    })
+    });
 
     bat.on('exit', (code) => {
       if (code === 0) {

--- a/src/k8s-engine/k8s.js
+++ b/src/k8s-engine/k8s.js
@@ -1,9 +1,9 @@
 'use strict';
 
-const { Minikube } = require('./minikube.js')
-const { OSNotImplemented } = require('./notimplemented.js')
+const { Minikube } = require('./minikube.js');
+const { OSNotImplemented } = require('./notimplemented.js');
 const { KubeClient } = require('./client');
-const os = require('os')
+const os = require('os');
 
 const State = {
   STOPPED: 0,  // The engine is not running.
@@ -12,7 +12,7 @@ const State = {
   READY: 3,    // The engine is started, and the dashboard is ready.
   STOPPING: 4, // The engine is attempting to stop.
   ERROR: 5,    // There is an error and we cannot recover automatically.
-}
+};
 
 Object.freeze(State);
 

--- a/src/k8s-engine/minikube.js
+++ b/src/k8s-engine/minikube.js
@@ -100,7 +100,7 @@ class Minikube extends EventEmitter {
       opts.env['MINIKUBE_HOME'] = paths.data();
       let resourcePath = resources.get(os.platform());
       let pth = Array.from(opts.env.PATH?.split(path.delimiter) ?? []);
-      pth.unshift(resourcePath)
+      pth.unshift(resourcePath);
       opts.env.PATH = pth.join(path.delimiter);
 
       // TODO: Handle platform differences
@@ -214,7 +214,7 @@ class Minikube extends EventEmitter {
       opts.env['MINIKUBE_HOME'] = paths.data();
       let resourcePath = resources.get(os.platform());
       let pth = Array.from(opts.env.PATH?.split(path.delimiter) ?? []);
-      pth.unshift(resourcePath)
+      pth.unshift(resourcePath);
       opts.env.PATH = pth.join(path.delimiter);
 
       // TODO: There MUST be a better way to exit. Do that.
@@ -242,7 +242,7 @@ class Minikube extends EventEmitter {
           reject({ context: "stopping minikube", errorCode: code, message: errorMessage });
         }
       });
-    })
+    });
   }
 
   async del() {
@@ -262,7 +262,7 @@ class Minikube extends EventEmitter {
       opts.env['MINIKUBE_HOME'] = paths.data();
       let resourcePath = resources.get(os.platform());
       let pth = Array.from(opts.env.PATH?.split(path.delimiter) ?? []);
-      pth.unshift(resourcePath)
+      pth.unshift(resourcePath);
       opts.env.PATH = pth.join(path.delimiter);
 
       // TODO: There MUST be a better way to exit. Do that.
@@ -287,7 +287,7 @@ class Minikube extends EventEmitter {
           reject({ context: "deleting minikube", errorCode: code, message: errorMessage });
         }
       });
-    })
+    });
   }
 
   clear() {
@@ -348,7 +348,7 @@ function quoteIfNecessary(s) {
 }
 
 function customizeMinikubeMessage(errorMessage) {
-  console.log(errorMessage)
+  console.log(errorMessage);
   let p = /X Exiting due to K8S_DOWNGRADE_UNSUPPORTED:\s*(Unable to safely downgrade .*?)\s+\*\s*Suggestion:\s+1\)\s*(Recreate the cluster with.*? by running:)\s+(minikube delete -p rancher-desktop)\s+(minikube start -p rancher-desktop --kubernetes-version=.*?)\n/s;
   let m = p.exec(errorMessage);
   if (m) {
@@ -363,9 +363,9 @@ export MINIKUBE_HOME=${quoteIfNecessary(paths.data())}
 ${m[3]}
 
 ${m[4]} --driver=hyperkit
-`
+`;
     // Keep this variable for future ease of logging
-    return fixedMessage
+    return fixedMessage;
   }
   return errorMessage;
 }

--- a/src/k8s-engine/notimplemented.js
+++ b/src/k8s-engine/notimplemented.js
@@ -1,7 +1,7 @@
 'use strict';
 
-const { dialog } = require('electron')
-const { State } = require('./k8s.js')
+const { dialog } = require('electron');
+const { State } = require('./k8s.js');
 
 /**
  * OSNotImplemented is a class for the case that a platform is not implemented.

--- a/src/main.js
+++ b/src/main.js
@@ -24,6 +24,6 @@ router.afterEach((to) => {
 
 new Vue({
   router,
-  render: h => h(App, { props: { navItems: routes } }),
-  el: "#app"
+  el: "#app",
+  render: h => h(App, { props: { navItems: routes } })
 });

--- a/src/main.js
+++ b/src/main.js
@@ -19,7 +19,7 @@ const router = new VueRouter({ routes });
 router.afterEach((to) => {
   Vue.nextTick(() => {
     document.title = to.meta.title || "Rancher Desktop";
-  })
+  });
 });
 
 new Vue({

--- a/src/menu/tray.js
+++ b/src/menu/tray.js
@@ -88,7 +88,7 @@ export class Tray extends EventEmitter {
       [State.READY]: 'Kubernetes is ready',
       [State.STOPPING]: 'Kubernetes is shutting down',
       [State.ERROR]: 'Kubernetes has encountered an error',
-    }
+    };
 
     let icon = resources.get('icons/kubernetes-icon-black.png');
     let logo = resources.get('icons/logo-square-bw.png');

--- a/vue.config.js
+++ b/vue.config.js
@@ -44,4 +44,4 @@ module.exports = {
       outputDir: 'dist/electron',
     }
   }
-}
+};


### PR DESCRIPTION
- We are using the wrong set of linters for vue (`vue/vue3-essential` instead of `vue/essential`).
- Also switch to `vue/recommended` to better fit into Vue projects.
- Additionally, lint for semicolon insertion.

Only the `package.json` changes are significant; the other changes are just automated fixes.

We probably want to delay landing this until the other big-ish PRs land first, though.