### PR TITLE
Checkbox wiring broke when backing from vue 3 to 2.

### DIFF
--- a/background.js
+++ b/background.js
@@ -197,7 +197,7 @@ ipcMain.on('install-set', async (event, name, newState) => {
     }
   } else {
     if (await refreshInstallState(name)) {
-      let err = new Promise((resolve) => { fs.unlink(linkPath, resolve) });
+      let err = await new Promise((resolve) => { fs.unlink(linkPath, resolve) });
       if (err) {
         console.error(`Error unlinking symlink for ${linkPath}`, err);
         event.reply('install-state', name, null);

--- a/package-lock.json
+++ b/package-lock.json
@@ -5095,9 +5095,9 @@
       }
     },
     "node_modules/@vue/cli-plugin-eslint/node_modules/webpack": {
-      "version": "5.17.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.17.0.tgz",
-      "integrity": "sha512-R+IdNEaYcYaACpXZOt7reyc8txBK7J06lOPkX1SbgmeoAnUbyBZivJIksrDBnmMA3wlTWvPcX7DubxELyPB8rA==",
+      "version": "5.18.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.18.0.tgz",
+      "integrity": "sha512-RmiP/iy6ROvVe/S+u0TrvL/oOmvP+2+Bs8MWjvBwwY/j82Q51XJyDJ75m0QAGntL1Wx6B//Xc0+4VPP/hlNHmw==",
       "dev": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.0",
@@ -32923,9 +32923,9 @@
           }
         },
         "webpack": {
-          "version": "5.17.0",
-          "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.17.0.tgz",
-          "integrity": "sha512-R+IdNEaYcYaACpXZOt7reyc8txBK7J06lOPkX1SbgmeoAnUbyBZivJIksrDBnmMA3wlTWvPcX7DubxELyPB8rA==",
+          "version": "5.18.0",
+          "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.18.0.tgz",
+          "integrity": "sha512-RmiP/iy6ROvVe/S+u0TrvL/oOmvP+2+Bs8MWjvBwwY/j82Q51XJyDJ75m0QAGntL1Wx6B//Xc0+4VPP/hlNHmw==",
           "dev": true,
           "requires": {
             "@types/eslint-scope": "^3.7.0",

--- a/src/components/Checkbox.vue
+++ b/src/components/Checkbox.vue
@@ -54,6 +54,8 @@ export default {
     clicked(event) {
       if (this.disabled) {
         event.preventDefault();
+      } else {
+        this.$emit('input', !this.value);
       }
     },
   }

--- a/src/components/K8s.vue
+++ b/src/components/K8s.vue
@@ -10,13 +10,13 @@
     <Checkbox :label="'link to /usr/local/bin/kubectl'"
               :disabled="symlinks.kubectl === null"
               :value="symlinks.kubectl"
-              @input="handleCheckbox($event, 'kubectl')"
+              @input="value => handleCheckbox(value, 'kubectl')"
              />
     <hr>
     <Checkbox :label="'link to /usr/local/bin/helm'"
               :disabled="symlinks.helm === null"
               :value="symlinks.helm"
-              @input="handleCheckbox($event, 'helm')"
+              @input="value => handleCheckbox(value, 'helm')"
     />
     <hr>
 
@@ -52,7 +52,7 @@ export default {
     cannotReset: function() {
       return (this.state !== K8s.State.STARTED && this.state !== K8s.State.READY);
     }
-  }, 
+  },
 
   methods: {
     // Reset a Kubernetes cluster to default at the same version
@@ -83,8 +83,8 @@ export default {
         }
       }
     },
-    handleCheckbox(event, name) {
-      ipcRenderer.send('install-set', name, event.target.checked);
+    handleCheckbox(value, name) {
+      ipcRenderer.send('install-set', name, value);
     }
   },
 

--- a/src/resources.js
+++ b/src/resources.js
@@ -3,6 +3,7 @@
 const { app } = require('electron');
 const os = require('os');
 const path = require('path');
+const fs = require('fs');
 
 /**
  * Get the path to a resource file
@@ -20,7 +21,12 @@ function get(...pathParts) {
  * @param {String} name The name of the binary, without file extension.
  */
 function executable(name) {
-    return get(os.platform(), /^win/i.test(os.platform()) ? `${name}.exe` : name);
+    let execPath = get(os.platform(), /^win/i.test(os.platform()) ? `${name}.exe` : name);
+    if (fs.existsSync(execPath)) {
+      return execPath;
+    }
+    let parts = path.parse(execPath);
+    return path.join(parts.dir, 'bin', parts.base);
 }
 
 module.exports = { get, executable };

--- a/src/resources.js
+++ b/src/resources.js
@@ -3,7 +3,7 @@
 const { app } = require('electron');
 const os = require('os');
 const path = require('path');
-const fs = require('fs');
+const memoize =  require('lodash/memoize');
 
 /**
  * Get the path to a resource file
@@ -20,13 +20,9 @@ function get(...pathParts) {
  * Get the path to an executable binary
  * @param {String} name The name of the binary, without file extension.
  */
-function executable(name) {
-    let execPath = get(os.platform(), /^win/i.test(os.platform()) ? `${name}.exe` : name);
-    if (fs.existsSync(execPath)) {
-      return execPath;
-    }
-    let parts = path.parse(execPath);
-    return path.join(parts.dir, 'bin', parts.base);
+function _executable(name) {
+  return get(os.platform(), /^win/i.test(os.platform()) ? `${name}.exe` : name);
 }
+const executable = memoize(_executable);
 
 module.exports = { get, executable };


### PR DESCRIPTION
This change brings it back

Also:
* allow resources to be in a .../bin dir
* add a missing await to a Promise call

The main reason for the breakage is that vuejs 3 bounces component events back to the parents automatically. In version 2 this has to be done manually.