### PR TITLE
Use k3s-enabled minikube

### DIFF
--- a/scripts/setupmac.js
+++ b/scripts/setupmac.js
@@ -5,7 +5,7 @@ const { spawn, spawnSync } = require('child_process');
 fs.mkdirSync("./resources/darwin/bin", { recursive: true });
 
 const file = fs.createWriteStream("./resources/darwin/minikube");
-https.get("https://github.com/kubernetes/minikube/releases/download/v1.14.0/minikube-darwin-amd64", function(response) {
+https.get("https://github.com/jandubois/minikube/releases/download/k3s0/minikube-darwin-amd64", function(response) {
   response.on('data', (data) => {
     file.write(data);
   });

--- a/src/k8s-engine/minikube.js
+++ b/src/k8s-engine/minikube.js
@@ -106,7 +106,7 @@ class Minikube extends EventEmitter {
       opts.env.PATH = pth.join(path.delimiter);
 
       // TODO: Handle platform differences
-      let args = ['start', '-p', 'rancher-desktop', '--driver', 'hyperkit', '--container-runtime', 'containerd', '--interactive=false'];
+      let args = ['start', '-b', 'k3s', '-p', 'rancher-desktop', '--driver', 'hyperkit', '--container-runtime', 'containerd', '--interactive=false'];
 
       // TODO: Handle the difference between changing version where a wipe is needed
       // and upgrading. All if there was a change.


### PR DESCRIPTION
This is just a draft PR for demonstration purposes; it replaces upstream minikube with a dev build that supports the k3s bootstrapper.

I couldn't find a way to stop the RD minikube VM via the UI, so I had to run this:

```
$ MINIKUBE_HOME="$HOME/Library/Application Support/rancher-desktop" minikube delete -p rancher-desktop
$ npm run-script setupmac
$ npm run dev
[...]
$ kubectl get no
NAME              STATUS   ROLES    AGE   VERSION
rancher-desktop   Ready    master   18s   v1.19.4+k3s2
```

I couldn't connect to `homestead` though; I tried opening `http://localhost:56107` in my browser, but the page never loaded. Maybe this is not the way to access it?