### PR TITLE
GitHub Actions: Package: Run setupmac

### DIFF
--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -23,6 +23,7 @@ jobs:
     - run: brew install giflib
     - run: brew install librsvg
     - run: npm ci
+    - run: npm run setupmac
     - run: npm run electron:build -- --mac --publish=never
     - uses: actions/upload-artifact@v2
       with:


### PR DESCRIPTION
Our packaged builds were missing pre-built binary resources.