### PR TITLE
package.json: add lint:nofix target

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -16,4 +16,4 @@ jobs:
         node-version: '14.x'
     - run: sudo apt-get install -y libcairo2-dev libpango1.0-dev libpng-dev libjpeg-dev libgif-dev librsvg2-dev
     - run: npm ci
-    - run: npm run lint
+    - run: npm run lint:nofix

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "0.0.1",
   "scripts": {
     "dev": "nuxtron dev",
-    "lint": "eslint --ignore-path=.gitignore --ext js,vue .",
+    "lint": "eslint --ignore-path=.gitignore --ext js,vue --fix .",
+    "lint:nofix": "eslint --ignore-path=.gitignore --ext js,vue .",
     "build": "node ./scripts/build.mjs",
     "generateReleases": "node ./scripts/generateReleaseList.js",
     "postinstall": "electron-builder install-app-deps",


### PR DESCRIPTION
Add a `npm run lint:nofix` for CI use, and change `npm run lint` to run fixes by default, so that developers can use that locally.

Opting to allow warnings on CI for now.