### PR TITLE
When the system is set to dark mode, use the dark theme

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5156,9 +5156,9 @@
       }
     },
     "node_modules/@octokit/openapi-types": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-4.0.1.tgz",
-      "integrity": "sha512-k2hRcfcLRyPJjtYfJLzg404n7HZ6sUpAWAR/uNI8tf96NgatWOpw1ocdF+WFfx/trO1ivBh7ckynO1rn+xAw/Q==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-4.0.2.tgz",
+      "integrity": "sha512-quqmeGTjcVks8YaatVGCpt7QpUTs2PK0D3mW5aEQqmFKOuIZ/CxwWrgnggPjqP3CNp6eALdQRgf0jUpcG8X1/Q==",
       "dev": true
     },
     "node_modules/@octokit/plugin-paginate-rest": {
@@ -5235,12 +5235,12 @@
       }
     },
     "node_modules/@octokit/types": {
-      "version": "6.8.2",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.8.2.tgz",
-      "integrity": "sha512-RpG0NJd7OKSkWptiFhy1xCLkThs5YoDIKM21lEtDmUvSpbaIEfrxzckWLUGDFfF8RydSyngo44gDv8m2hHruUg==",
+      "version": "6.8.3",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.8.3.tgz",
+      "integrity": "sha512-ZNAy8z77ewKZ5LCX0KaUm4tWdgloWQ6FWJCh06qgahq/MH13sQefIPKSo0dBdPU3bcioltyZUcC0k8oHHfjvnQ==",
       "dev": true,
       "dependencies": {
-        "@octokit/openapi-types": "^4.0.0",
+        "@octokit/openapi-types": "^4.0.2",
         "@types/node": ">= 8"
       }
     },
@@ -14555,9 +14555,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.3.660",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.660.tgz",
-      "integrity": "sha512-UOSKNfUBY8FDOSo4mfaUsN3KftlNLcYOg9v5apqLvNcWj+Ogy/i9SEDMZpfSVOeDkOcpu9iusucX6jxTWzqGLA==",
+      "version": "1.3.662",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.662.tgz",
+      "integrity": "sha512-IGBXmTGwdVGUVTnZ8ISEvkhDfhhD+CDFndG4//BhvDcEtPYiVrzoB+rzT/Y12OQCf5bvRCrVmrUbGrS9P7a6FQ==",
       "dev": true
     },
     "node_modules/electron/node_modules/@types/node": {
@@ -15193,9 +15193,9 @@
       }
     },
     "node_modules/eslint-plugin-promise": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-4.2.1.tgz",
-      "integrity": "sha512-VoM09vT7bfA7D+upt+FjeBO5eHIJQBUWki1aPvB+vbNiHS3+oGIJGIeyBtKQTME6UPXXy3vV07OL1tHd3ANuDw==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-4.3.1.tgz",
+      "integrity": "sha512-bY2sGqyptzFBDLh/GMbAxfdJC+b0f23ME63FOE4+Jao0oZ3E1LEwFtWJX/1pGMJLiTtrSSern2CRM/g+dfc0eQ==",
       "dev": true,
       "engines": {
         "node": ">=6"
@@ -16555,6 +16555,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/filter-obj": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/filter-obj/-/filter-obj-1.1.0.tgz",
+      "integrity": "sha1-mzERErxsYSehbgFsbF1/GeCAXFs=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/finalhandler": {
@@ -21278,9 +21287,9 @@
       }
     },
     "node_modules/jszip": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.5.0.tgz",
-      "integrity": "sha512-WRtu7TPCmYePR1nazfrtuF216cIVon/3GWOvHS9QR5bIwSbnxtdpma6un3jyGGNhHsKCSzn5Ypk+EkDRvTGiFA==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.6.0.tgz",
+      "integrity": "sha512-jgnQoG9LKnWO3mnVNBnfhkh0QknICd1FGSrXcgrl67zioyJ4wgx25o9ZqwNtrROSflGBCGYnJfjrIyRIby1OoQ==",
       "dev": true,
       "dependencies": {
         "lie": "~3.3.0",
@@ -25889,12 +25898,13 @@
       }
     },
     "node_modules/parse-path/node_modules/query-string": {
-      "version": "6.13.8",
-      "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.13.8.tgz",
-      "integrity": "sha512-jxJzQI2edQPE/NPUOusNjO/ZOGqr1o2OBa/3M00fU76FsLXDVbJDv/p7ng5OdQyorKrkRz1oqfwmbe5MAMePQg==",
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.14.0.tgz",
+      "integrity": "sha512-In3o+lUxlgejoVJgwEdYtdxrmlL0cQWJXj0+kkI7RWVo7hg5AhFtybeKlC9Dpgbr8eOC4ydpEh8017WwyfzqVQ==",
       "dev": true,
       "dependencies": {
         "decode-uri-component": "^0.2.0",
+        "filter-obj": "^1.1.0",
         "split-on-first": "^1.0.0",
         "strict-uri-encode": "^2.0.0"
       },
@@ -28088,6 +28098,26 @@
       "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
       "dev": true
     },
+    "node_modules/queue-microtask": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.2.tgz",
+      "integrity": "sha512-dB15eXv3p2jDlbOiNLyMabYg1/sXvppd8DP2J3EOCQ0AkuSXCW2tP7mnVouVLJKgUMY6yP0kcQDVpLCN13h4Xg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
     "node_modules/quick-lru": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
@@ -29049,9 +29079,9 @@
       }
     },
     "node_modules/run-parallel": {
-      "version": "1.1.10",
-      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.10.tgz",
-      "integrity": "sha512-zb/1OuZ6flOlH6tQyMPUrE3x3Ulxjlo9WIVXR4yVYi4H9UXQaeIsPbLn2R3O3vQCnDKkAl2qHiuocKKX4Tz/Sw==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
       "dev": true,
       "funding": [
         {
@@ -29066,7 +29096,10 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ]
+      ],
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
     },
     "node_modules/run-queue": {
       "version": "1.0.3",
@@ -29163,9 +29196,9 @@
       }
     },
     "node_modules/sass": {
-      "version": "1.32.6",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.32.6.tgz",
-      "integrity": "sha512-1bcDHDcSqeFtMr0JXI3xc/CXX6c4p0wHHivJdru8W7waM7a1WjKMm4m/Z5sY7CbVw4Whi2Chpcw6DFfSWwGLzQ==",
+      "version": "1.32.7",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.32.7.tgz",
+      "integrity": "sha512-C8Z4bjqGWnsYa11o8hpKAuoyFdRhrSHcYjCr+XAWVPSIQqC8mp2f5Dx4em0dKYehPzg5XSekmCjqJnEZbIls9A==",
       "dependencies": {
         "chokidar": ">=2.0.0 <4.0.0"
       },
@@ -32449,9 +32482,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "3.9.8",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.8.tgz",
-      "integrity": "sha512-nDbnFkUZZjkQ92qwKX+C+jtk4OGfU8H9toSEs3uAsl8cxLjG2sqQm6leF/pLWvm9FAEJ6KHkYMAbHYaY2ITeVg==",
+      "version": "3.9.9",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.9.tgz",
+      "integrity": "sha512-kdMjTiekY+z/ubJCATUPlRDl39vXYiMV9iyeMuEuXZh2we6zz80uovNN2WlAxmmdE/Z/YQe+EbOEXB5RHEED3w==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -40452,9 +40485,9 @@
       }
     },
     "@octokit/openapi-types": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-4.0.1.tgz",
-      "integrity": "sha512-k2hRcfcLRyPJjtYfJLzg404n7HZ6sUpAWAR/uNI8tf96NgatWOpw1ocdF+WFfx/trO1ivBh7ckynO1rn+xAw/Q==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-4.0.2.tgz",
+      "integrity": "sha512-quqmeGTjcVks8YaatVGCpt7QpUTs2PK0D3mW5aEQqmFKOuIZ/CxwWrgnggPjqP3CNp6eALdQRgf0jUpcG8X1/Q==",
       "dev": true
     },
     "@octokit/plugin-paginate-rest": {
@@ -40523,12 +40556,12 @@
       }
     },
     "@octokit/types": {
-      "version": "6.8.2",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.8.2.tgz",
-      "integrity": "sha512-RpG0NJd7OKSkWptiFhy1xCLkThs5YoDIKM21lEtDmUvSpbaIEfrxzckWLUGDFfF8RydSyngo44gDv8m2hHruUg==",
+      "version": "6.8.3",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.8.3.tgz",
+      "integrity": "sha512-ZNAy8z77ewKZ5LCX0KaUm4tWdgloWQ6FWJCh06qgahq/MH13sQefIPKSo0dBdPU3bcioltyZUcC0k8oHHfjvnQ==",
       "dev": true,
       "requires": {
-        "@octokit/openapi-types": "^4.0.0",
+        "@octokit/openapi-types": "^4.0.2",
         "@types/node": ">= 8"
       }
     },
@@ -48303,9 +48336,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.3.660",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.660.tgz",
-      "integrity": "sha512-UOSKNfUBY8FDOSo4mfaUsN3KftlNLcYOg9v5apqLvNcWj+Ogy/i9SEDMZpfSVOeDkOcpu9iusucX6jxTWzqGLA==",
+      "version": "1.3.662",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.662.tgz",
+      "integrity": "sha512-IGBXmTGwdVGUVTnZ8ISEvkhDfhhD+CDFndG4//BhvDcEtPYiVrzoB+rzT/Y12OQCf5bvRCrVmrUbGrS9P7a6FQ==",
       "dev": true
     },
     "elegant-spinner": {
@@ -48889,9 +48922,9 @@
       }
     },
     "eslint-plugin-promise": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-4.2.1.tgz",
-      "integrity": "sha512-VoM09vT7bfA7D+upt+FjeBO5eHIJQBUWki1aPvB+vbNiHS3+oGIJGIeyBtKQTME6UPXXy3vV07OL1tHd3ANuDw==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-4.3.1.tgz",
+      "integrity": "sha512-bY2sGqyptzFBDLh/GMbAxfdJC+b0f23ME63FOE4+Jao0oZ3E1LEwFtWJX/1pGMJLiTtrSSern2CRM/g+dfc0eQ==",
       "dev": true
     },
     "eslint-plugin-standard": {
@@ -49847,6 +49880,12 @@
       "requires": {
         "to-regex-range": "^5.0.1"
       }
+    },
+    "filter-obj": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/filter-obj/-/filter-obj-1.1.0.tgz",
+      "integrity": "sha1-mzERErxsYSehbgFsbF1/GeCAXFs=",
+      "dev": true
     },
     "finalhandler": {
       "version": "1.1.2",
@@ -53627,9 +53666,9 @@
       }
     },
     "jszip": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.5.0.tgz",
-      "integrity": "sha512-WRtu7TPCmYePR1nazfrtuF216cIVon/3GWOvHS9QR5bIwSbnxtdpma6un3jyGGNhHsKCSzn5Ypk+EkDRvTGiFA==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.6.0.tgz",
+      "integrity": "sha512-jgnQoG9LKnWO3mnVNBnfhkh0QknICd1FGSrXcgrl67zioyJ4wgx25o9ZqwNtrROSflGBCGYnJfjrIyRIby1OoQ==",
       "dev": true,
       "requires": {
         "lie": "~3.3.0",
@@ -57307,12 +57346,13 @@
           "dev": true
         },
         "query-string": {
-          "version": "6.13.8",
-          "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.13.8.tgz",
-          "integrity": "sha512-jxJzQI2edQPE/NPUOusNjO/ZOGqr1o2OBa/3M00fU76FsLXDVbJDv/p7ng5OdQyorKrkRz1oqfwmbe5MAMePQg==",
+          "version": "6.14.0",
+          "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.14.0.tgz",
+          "integrity": "sha512-In3o+lUxlgejoVJgwEdYtdxrmlL0cQWJXj0+kkI7RWVo7hg5AhFtybeKlC9Dpgbr8eOC4ydpEh8017WwyfzqVQ==",
           "dev": true,
           "requires": {
             "decode-uri-component": "^0.2.0",
+            "filter-obj": "^1.1.0",
             "split-on-first": "^1.0.0",
             "strict-uri-encode": "^2.0.0"
           }
@@ -59154,6 +59194,12 @@
       "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
       "dev": true
     },
+    "queue-microtask": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.2.tgz",
+      "integrity": "sha512-dB15eXv3p2jDlbOiNLyMabYg1/sXvppd8DP2J3EOCQ0AkuSXCW2tP7mnVouVLJKgUMY6yP0kcQDVpLCN13h4Xg==",
+      "dev": true
+    },
     "quick-lru": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
@@ -59926,10 +59972,13 @@
       "dev": true
     },
     "run-parallel": {
-      "version": "1.1.10",
-      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.10.tgz",
-      "integrity": "sha512-zb/1OuZ6flOlH6tQyMPUrE3x3Ulxjlo9WIVXR4yVYi4H9UXQaeIsPbLn2R3O3vQCnDKkAl2qHiuocKKX4Tz/Sw==",
-      "dev": true
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "requires": {
+        "queue-microtask": "^1.2.2"
+      }
     },
     "run-queue": {
       "version": "1.0.3",
@@ -60016,9 +60065,9 @@
       }
     },
     "sass": {
-      "version": "1.32.6",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.32.6.tgz",
-      "integrity": "sha512-1bcDHDcSqeFtMr0JXI3xc/CXX6c4p0wHHivJdru8W7waM7a1WjKMm4m/Z5sY7CbVw4Whi2Chpcw6DFfSWwGLzQ==",
+      "version": "1.32.7",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.32.7.tgz",
+      "integrity": "sha512-C8Z4bjqGWnsYa11o8hpKAuoyFdRhrSHcYjCr+XAWVPSIQqC8mp2f5Dx4em0dKYehPzg5XSekmCjqJnEZbIls9A==",
       "requires": {
         "chokidar": ">=2.0.0 <4.0.0"
       }
@@ -62707,9 +62756,9 @@
       }
     },
     "typescript": {
-      "version": "3.9.8",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.8.tgz",
-      "integrity": "sha512-nDbnFkUZZjkQ92qwKX+C+jtk4OGfU8H9toSEs3uAsl8cxLjG2sqQm6leF/pLWvm9FAEJ6KHkYMAbHYaY2ITeVg==",
+      "version": "3.9.9",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.9.tgz",
+      "integrity": "sha512-kdMjTiekY+z/ubJCATUPlRDl39vXYiMV9iyeMuEuXZh2we6zz80uovNN2WlAxmmdE/Z/YQe+EbOEXB5RHEED3w==",
       "dev": true
     },
     "ua-parser-js": {

--- a/src/assets/styles/app.scss
+++ b/src/assets/styles/app.scss
@@ -13,8 +13,11 @@
 @import "./fonts/zerowidthspace";
 @import "./fonts/icons";
 
+
 @import "./themes/light";
-@import "./themes/dark";
+@media screen and (prefers-color-scheme: dark) {
+  @import "./themes/dark";
+}
 
 // @import "./global/columns";
 @import "./global/cards";

--- a/src/layouts/default.vue
+++ b/src/layouts/default.vue
@@ -17,6 +17,17 @@ export default {
     Header,
   },
 
+  head() {
+    // If dark-mode is set to auto (follow system-prefs) this is all we need
+    // In a possible future with a three-way pref
+    // (Always off // Always on // Follow system pref)
+    // the "dark" part will be a dynamic pref.
+    // See https://github.com/rancher/dashboard/blob/3454590ff6a825f7e739356069576fbae4afaebc/layouts/default.vue#L227 for an example
+    return {
+      bodyAttrs: { class: 'theme-dark' },
+    };
+  },
+
   data() {
     return {
       routes: ['/Welcome', '/K8s', '/Troubleshooting'],
@@ -31,6 +42,7 @@ export default {
 .wrapper {
   display: grid;
   grid-template-columns: repeat(4, 1fr);
+  background-color: var(--body-bg);
 
   .header {
     grid-column: 1 / 5;

--- a/src/layouts/default.vue
+++ b/src/layouts/default.vue
@@ -17,6 +17,12 @@ export default {
     Header,
   },
 
+  data() {
+    return {
+      routes: ['/Welcome', '/K8s', '/Troubleshooting'],
+    };
+  },
+
   head() {
     // If dark-mode is set to auto (follow system-prefs) this is all we need
     // In a possible future with a three-way pref
@@ -25,12 +31,6 @@ export default {
     // See https://github.com/rancher/dashboard/blob/3454590ff6a825f7e739356069576fbae4afaebc/layouts/default.vue#L227 for an example
     return {
       bodyAttrs: { class: 'theme-dark' },
-    };
-  },
-
-  data() {
-    return {
-      routes: ['/Welcome', '/K8s', '/Troubleshooting'],
     };
   },
 };


### PR DESCRIPTION
Only tested on macos

Dashboard currently has three modes: always light, always dark,
and follow system mode.  This branch implements only the last choice.
To test:

System Preferences > General > Appearance